### PR TITLE
JWT 인증/인가 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,11 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // jwt
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/server/crews/application/domain/Application.java
+++ b/src/main/java/com/server/crews/application/domain/Application.java
@@ -1,0 +1,23 @@
+package com.server.crews.application.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter
+@Document(collection = "recruitments")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Application {
+    @Id
+    private String id;
+
+    @Indexed(unique = true)
+    private String secretCode;
+
+    public Application(final String secretCode) {
+        this.secretCode = secretCode;
+    }
+}

--- a/src/main/java/com/server/crews/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/server/crews/application/repository/ApplicationRepository.java
@@ -1,0 +1,9 @@
+package com.server.crews.application.repository;
+
+import com.server.crews.application.domain.Application;
+import java.util.Optional;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface ApplicationRepository extends MongoRepository<Application, String> {
+    Optional<Application> findBySecretCode(String code);
+}

--- a/src/main/java/com/server/crews/auth/application/AuthService.java
+++ b/src/main/java/com/server/crews/auth/application/AuthService.java
@@ -80,4 +80,24 @@ public class AuthService {
             throw new CrewsException(ErrorCode.DUPLICATE_SECRET_CODE);
         }
     }
+
+    public Object createAuthentication(final String accessToken) {
+        jwtTokenProvider.validateAccessToken(accessToken);
+        String id = jwtTokenProvider.getPayload(accessToken);
+        Role role = jwtTokenProvider.getRole(accessToken);
+        if(role.equals(Role.ADMIN)) {
+            return validateExistingRecruitment(id);
+        }
+        return validateExistingApplication(id);
+    }
+
+    private Recruitment validateExistingRecruitment(final String id) {
+        return recruitmentRepository.findById(id)
+                .orElseThrow(() -> new CrewsException(ErrorCode.RECRUITMENT_NOT_FOUND));
+    }
+
+    private Application validateExistingApplication(final String id) {
+        return applicationRepository.findById(id)
+                .orElseThrow(() -> new CrewsException(ErrorCode.APPLICATION_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/server/crews/auth/application/AuthService.java
+++ b/src/main/java/com/server/crews/auth/application/AuthService.java
@@ -1,5 +1,6 @@
 package com.server.crews.auth.application;
 
+import com.server.crews.application.domain.Application;
 import com.server.crews.application.repository.ApplicationRepository;
 import com.server.crews.auth.domain.Role;
 import com.server.crews.auth.dto.request.NewSecretCodeRequest;
@@ -56,6 +57,21 @@ public class AuthService {
 
     private void validateDuplicatedRecruitmentCode(final String code) {
         Recruitment existing = recruitmentRepository.findBySecretCode(code).orElse(null);
+        validateDuplicated(existing);
+    }
+
+    public TokenResponse createApplicationCode(final NewSecretCodeRequest request) {
+        String code = request.code();
+        validateDuplicatedApplicationCode(code);
+        Application application = applicationRepository.save(new Application(code));
+        String id = application.getId();
+
+        String accessToken = jwtTokenProvider.createAccessToken(Role.APPLICANT, id);
+        return new TokenResponse(id, accessToken);
+    }
+
+    private void validateDuplicatedApplicationCode(final String code) {
+        Application existing = applicationRepository.findBySecretCode(code).orElse(null);
         validateDuplicated(existing);
     }
 

--- a/src/main/java/com/server/crews/auth/application/AuthService.java
+++ b/src/main/java/com/server/crews/auth/application/AuthService.java
@@ -1,0 +1,67 @@
+package com.server.crews.auth.application;
+
+import com.server.crews.application.repository.ApplicationRepository;
+import com.server.crews.auth.domain.Role;
+import com.server.crews.auth.dto.request.NewSecretCodeRequest;
+import com.server.crews.auth.dto.response.TokenResponse;
+import com.server.crews.global.exception.CrewsException;
+import com.server.crews.global.exception.ErrorCode;
+import com.server.crews.recruitment.domain.Recruitment;
+import com.server.crews.recruitment.repository.RecruitmentRepository;
+import jakarta.servlet.http.Cookie;
+import java.util.Objects;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthService {
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RecruitmentRepository recruitmentRepository;
+    private final ApplicationRepository applicationRepository;
+
+    private final int refreshTokenValidityInSecond;
+
+    public AuthService(
+            final JwtTokenProvider jwtTokenProvider,
+            final RecruitmentRepository recruitmentRepository,
+            final ApplicationRepository applicationRepository,
+            @Value("${jwt.refresh-token-validity}") final int refreshTokenValidityInMilliseconds) {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.recruitmentRepository = recruitmentRepository;
+        this.applicationRepository = applicationRepository;
+        this.refreshTokenValidityInSecond = refreshTokenValidityInMilliseconds / 1000;
+    }
+
+    public TokenResponse createRecruitmentCode(final NewSecretCodeRequest request) {
+        String code = request.code();
+        validateDuplicatedRecruitmentCode(code);
+        Recruitment recruitment = recruitmentRepository.save(new Recruitment(code));
+        String id = recruitment.getId();
+
+        String accessToken = jwtTokenProvider.createAccessToken(Role.ADMIN, id);
+        return new TokenResponse(id, accessToken);
+    }
+
+    public HttpHeaders createRefreshToken(Role role, String id) {
+        String refreshToken = jwtTokenProvider.createRefreshToken(role, id);
+
+        HttpHeaders headers = new HttpHeaders();
+        Cookie cookie = new Cookie("refreshToken", refreshToken);
+        cookie.setMaxAge(refreshTokenValidityInSecond);
+
+        headers.add(HttpHeaders.SET_COOKIE, cookie.toString());
+        return headers;
+    }
+
+    private void validateDuplicatedRecruitmentCode(final String code) {
+        Recruitment existing = recruitmentRepository.findBySecretCode(code).orElse(null);
+        validateDuplicated(existing);
+    }
+
+    private void validateDuplicated(Object existing) {
+        if(Objects.isNull(existing)) {
+            throw new CrewsException(ErrorCode.DUPLICATE_SECRET_CODE);
+        }
+    }
+}

--- a/src/main/java/com/server/crews/auth/application/AuthService.java
+++ b/src/main/java/com/server/crews/auth/application/AuthService.java
@@ -9,10 +9,9 @@ import com.server.crews.global.exception.CrewsException;
 import com.server.crews.global.exception.ErrorCode;
 import com.server.crews.recruitment.domain.Recruitment;
 import com.server.crews.recruitment.repository.RecruitmentRepository;
-import jakarta.servlet.http.Cookie;
 import java.util.Objects;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -44,15 +43,16 @@ public class AuthService {
         return new TokenResponse(id, accessToken);
     }
 
-    public HttpHeaders createRefreshToken(Role role, String id) {
+    public ResponseCookie createRefreshToken(Role role, String id) {
         String refreshToken = jwtTokenProvider.createRefreshToken(role, id);
 
-        HttpHeaders headers = new HttpHeaders();
-        Cookie cookie = new Cookie("refreshToken", refreshToken);
-        cookie.setMaxAge(refreshTokenValidityInSecond);
-
-        headers.add(HttpHeaders.SET_COOKIE, cookie.toString());
-        return headers;
+        ResponseCookie responseCookie = ResponseCookie.from("refreshToken", refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .path("/auth/refresh")
+                .maxAge(refreshTokenValidityInSecond)
+                .build();
+        return responseCookie;
     }
 
     private void validateDuplicatedRecruitmentCode(final String code) {

--- a/src/main/java/com/server/crews/auth/application/AuthService.java
+++ b/src/main/java/com/server/crews/auth/application/AuthService.java
@@ -76,7 +76,7 @@ public class AuthService {
     }
 
     private void validateDuplicated(Object existing) {
-        if(Objects.isNull(existing)) {
+        if(Objects.nonNull(existing)) {
             throw new CrewsException(ErrorCode.DUPLICATE_SECRET_CODE);
         }
     }

--- a/src/main/java/com/server/crews/auth/application/JwtTokenProvider.java
+++ b/src/main/java/com/server/crews/auth/application/JwtTokenProvider.java
@@ -1,0 +1,122 @@
+package com.server.crews.auth.application;
+
+import static io.jsonwebtoken.SignatureAlgorithm.HS256;
+import static io.jsonwebtoken.SignatureAlgorithm.HS384;
+
+import com.server.crews.auth.domain.Role;
+import com.server.crews.global.exception.CrewsException;
+import com.server.crews.global.exception.ErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider {
+    private static final SignatureAlgorithm ACCESS_TOKEN_ALGORITHM = HS256;
+    private static final SignatureAlgorithm REFRESH_TOKEN_ALGORITHM = HS384;
+
+    private final Key key;
+    private final long accessTokenValidityInMilliseconds;
+    private final long refreshTokenValidityInMilliseconds;
+
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") final String secret,
+            @Value("${jwt.access-token-validity}") final long accessTokenValidityInMilliseconds,
+            @Value("${jwt.refresh-token-validity}") final long refreshTokenValidityInMilliseconds) {
+        this.key = decodeSecretKey(secret);
+        this.accessTokenValidityInMilliseconds = accessTokenValidityInMilliseconds;
+        this.refreshTokenValidityInMilliseconds = refreshTokenValidityInMilliseconds;
+    }
+
+    private Key decodeSecretKey(final String secret) {
+        byte[] keyBytes = Decoders.BASE64.decode(secret);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String createAccessToken(final Role role, final String payload) {
+        return createToken(
+                role, payload, accessTokenValidityInMilliseconds, ACCESS_TOKEN_ALGORITHM);
+    }
+
+    public String createRefreshToken(final Role role, final String payload) {
+        return createToken(
+                role, payload, refreshTokenValidityInMilliseconds, REFRESH_TOKEN_ALGORITHM);
+    }
+
+    private String createToken(
+            final Role role,
+            final String payload,
+            final long validityInMilliseconds,
+            final SignatureAlgorithm algorithm) {
+        Claims claims = Jwts.claims().setSubject(payload);
+        claims.put("role", role.name());
+
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + validityInMilliseconds);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setExpiration(validity)
+                .signWith(algorithm, key)
+                .compact();
+    }
+
+    public String getPayload(final String token) {
+        return Jwts.parser()
+                .setSigningKey(key)
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+
+    public Role getRole(final String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        return Role.valueOf((String) claims.get("role"));
+    }
+
+    public boolean validateAccessToken(String token) {
+        if(!validateToken(token).equals(ACCESS_TOKEN_ALGORITHM)) {
+            throw new CrewsException(ErrorCode.INVALID_ACCESS_TOKEN);
+        }
+        return true;
+    }
+
+    public boolean validateRefreshToken(String token) {
+        if(!validateToken(token).equals(REFRESH_TOKEN_ALGORITHM)) {
+            throw new CrewsException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+        return true;
+    }
+
+    private SignatureAlgorithm validateToken(String token) {
+        try {
+            String algorithm = Jwts.parser()
+                    .setSigningKey(key)
+                    .parseClaimsJws(token)
+                    .getHeader()
+                    .getAlgorithm();
+            return SignatureAlgorithm.forName(algorithm);
+        } catch (MalformedJwtException e) {
+            throw new CrewsException(ErrorCode.MALFORMED_JWT);
+        } catch (ExpiredJwtException e) {
+            throw new CrewsException(ErrorCode.EXPIRED_JWT);
+        } catch (UnsupportedJwtException e) {
+            throw new CrewsException(ErrorCode.UNSUPPORTED_JWT);
+        } catch (IllegalArgumentException e) {
+            throw new CrewsException(ErrorCode.INVALID_JWT);
+        }
+    }
+}

--- a/src/main/java/com/server/crews/auth/config/AuthArgumentResolverConfig.java
+++ b/src/main/java/com/server/crews/auth/config/AuthArgumentResolverConfig.java
@@ -1,0 +1,18 @@
+package com.server.crews.auth.config;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class AuthArgumentResolverConfig implements WebMvcConfigurer {
+    private final HandlerMethodArgumentResolver authenticationArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authenticationArgumentResolver);
+    }
+}

--- a/src/main/java/com/server/crews/auth/domain/Role.java
+++ b/src/main/java/com/server/crews/auth/domain/Role.java
@@ -1,0 +1,6 @@
+package com.server.crews.auth.domain;
+
+public enum Role {
+    ADMIN,
+    APPLICANT;
+}

--- a/src/main/java/com/server/crews/auth/dto/request/NewSecretCodeRequest.java
+++ b/src/main/java/com/server/crews/auth/dto/request/NewSecretCodeRequest.java
@@ -1,0 +1,5 @@
+package com.server.crews.auth.dto.request;
+
+public record NewSecretCodeRequest(String code) {
+
+}

--- a/src/main/java/com/server/crews/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/server/crews/auth/dto/response/TokenResponse.java
@@ -1,0 +1,5 @@
+package com.server.crews.auth.dto.response;
+
+public record TokenResponse(String id, String accessToken) {
+
+}

--- a/src/main/java/com/server/crews/auth/presentation/AuthController.java
+++ b/src/main/java/com/server/crews/auth/presentation/AuthController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,8 +26,10 @@ public class AuthController {
     public ResponseEntity<TokenResponse> createRecruitmentSecretCode(
             @RequestBody final NewSecretCodeRequest request) {
         TokenResponse tokenResponse = authService.createRecruitmentCode(request);
-        HttpHeaders headers = authService.createRefreshToken(Role.ADMIN, tokenResponse.id());
-        return ResponseEntity.status(HttpStatus.CREATED).headers(headers).body(tokenResponse);
+        ResponseCookie cookie = authService.createRefreshToken(Role.ADMIN, tokenResponse.id());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .body(tokenResponse);
     }
 
     @PostMapping("/application/secret-code")
@@ -34,7 +37,9 @@ public class AuthController {
     public ResponseEntity<TokenResponse> createApplicationSecretCode(
             @RequestBody final NewSecretCodeRequest request) {
         TokenResponse tokenResponse = authService.createApplicationCode(request);
-        HttpHeaders headers = authService.createRefreshToken(Role.APPLICANT, tokenResponse.id());
-        return ResponseEntity.status(HttpStatus.CREATED).headers(headers).body(tokenResponse);
+        ResponseCookie cookie = authService.createRefreshToken(Role.APPLICANT, tokenResponse.id());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .body(tokenResponse);
     }
 }

--- a/src/main/java/com/server/crews/auth/presentation/AuthController.java
+++ b/src/main/java/com/server/crews/auth/presentation/AuthController.java
@@ -22,10 +22,19 @@ public class AuthController {
 
     @PostMapping("/recruitment/secret-code")
     @Operation(description = "지원서 양식에 대한 코드를 생성한다.")
-    public ResponseEntity<TokenResponse> createSecretCode(
+    public ResponseEntity<TokenResponse> createRecruitmentSecretCode(
             @RequestBody final NewSecretCodeRequest request) {
         TokenResponse tokenResponse = authService.createRecruitmentCode(request);
         HttpHeaders headers = authService.createRefreshToken(Role.ADMIN, tokenResponse.id());
+        return ResponseEntity.status(HttpStatus.CREATED).headers(headers).body(tokenResponse);
+    }
+
+    @PostMapping("/application/secret-code")
+    @Operation(description = "지원서에 대한 코드를 생성한다.")
+    public ResponseEntity<TokenResponse> createApplicationSecretCode(
+            @RequestBody final NewSecretCodeRequest request) {
+        TokenResponse tokenResponse = authService.createApplicationCode(request);
+        HttpHeaders headers = authService.createRefreshToken(Role.APPLICANT, tokenResponse.id());
         return ResponseEntity.status(HttpStatus.CREATED).headers(headers).body(tokenResponse);
     }
 }

--- a/src/main/java/com/server/crews/auth/presentation/AuthController.java
+++ b/src/main/java/com/server/crews/auth/presentation/AuthController.java
@@ -1,0 +1,31 @@
+package com.server.crews.auth.presentation;
+
+import com.server.crews.auth.application.AuthService;
+import com.server.crews.auth.domain.Role;
+import com.server.crews.auth.dto.request.NewSecretCodeRequest;
+import com.server.crews.auth.dto.response.TokenResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/recruitment/secret-code")
+    @Operation(description = "지원서 양식에 대한 코드를 생성한다.")
+    public ResponseEntity<TokenResponse> createSecretCode(
+            @RequestBody final NewSecretCodeRequest request) {
+        TokenResponse tokenResponse = authService.createRecruitmentCode(request);
+        HttpHeaders headers = authService.createRefreshToken(Role.ADMIN, tokenResponse.id());
+        return ResponseEntity.status(HttpStatus.CREATED).headers(headers).body(tokenResponse);
+    }
+}

--- a/src/main/java/com/server/crews/auth/presentation/Authentication.java
+++ b/src/main/java/com/server/crews/auth/presentation/Authentication.java
@@ -1,0 +1,11 @@
+package com.server.crews.auth.presentation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Authentication {
+}

--- a/src/main/java/com/server/crews/auth/presentation/AuthenticationArgumentResolver.java
+++ b/src/main/java/com/server/crews/auth/presentation/AuthenticationArgumentResolver.java
@@ -1,0 +1,31 @@
+package com.server.crews.auth.presentation;
+
+import com.server.crews.auth.application.AuthService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticationArgumentResolver implements HandlerMethodArgumentResolver {
+    private final AuthService authService;
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(Authentication.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            final MethodParameter parameter, final ModelAndViewContainer mavContainer,
+            final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) {
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        String accessToken = AuthorizationExtractor.extract(request);
+        return authService.createAuthentication(accessToken);
+    }
+}

--- a/src/main/java/com/server/crews/auth/presentation/AuthorizationExtractor.java
+++ b/src/main/java/com/server/crews/auth/presentation/AuthorizationExtractor.java
@@ -1,0 +1,27 @@
+package com.server.crews.auth.presentation;
+
+import com.server.crews.global.exception.CrewsException;
+import com.server.crews.global.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Objects;
+import org.springframework.http.HttpHeaders;
+
+public class AuthorizationExtractor {
+    private static final String BEARER_TYPE = "Bearer ";
+
+    public static String extract(final HttpServletRequest request) {
+        String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (Objects.isNull(authorizationHeader)) {
+            throw new CrewsException(ErrorCode.NO_TOKEN);
+        }
+
+        validateAuthorizationFormat(authorizationHeader);
+        return authorizationHeader.substring(BEARER_TYPE.length()).trim();
+    }
+
+    private static void validateAuthorizationFormat(final String authorizationHeader) {
+        if (!authorizationHeader.toLowerCase().startsWith(BEARER_TYPE.toLowerCase())) {
+            throw new CrewsException(ErrorCode.INVALID_TOKEN);
+        }
+    }
+}

--- a/src/main/java/com/server/crews/global/exception/ErrorCode.java
+++ b/src/main/java/com/server/crews/global/exception/ErrorCode.java
@@ -8,7 +8,19 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode {
     DUPLICATE_SECRET_CODE(HttpStatus.BAD_REQUEST, "중복된 코드입니다."),
-    NO_PARAMETER(HttpStatus.BAD_REQUEST, "%s 파라미터가 없습니다.");
+    NO_PARAMETER(HttpStatus.BAD_REQUEST, "%s 파라미터가 없습니다."),
+
+    NO_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "토큰 형식이 잘못 되었습니다."),
+    MALFORMED_JWT(HttpStatus.UNAUTHORIZED, "잘못된 JWT 서명입니다."),
+    EXPIRED_JWT(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다."),
+    UNSUPPORTED_JWT(HttpStatus.UNAUTHORIZED, "지원되지 않는 JWT 토큰입니다."),
+    INVALID_JWT(HttpStatus.UNAUTHORIZED, "JWT 토큰이 잘못되었습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 refresh token 입니다."),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 access token 입니다."),
+
+    RECRUITMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 모집 지원서 양식입니다."),
+    APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 지원서입니다.");
 
     private HttpStatus httpStatus;
     private String message;

--- a/src/main/java/com/server/crews/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/server/crews/recruitment/domain/Recruitment.java
@@ -13,8 +13,6 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Getter
 @Document(collection = "recruitments")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Builder
 public class Recruitment {
     @Id
     private String id;
@@ -29,4 +27,8 @@ public class Recruitment {
     private Progress progress;
 
     private List<Section> sections;
+
+    public Recruitment(final String secretCode) {
+        this.secretCode = secretCode;
+    }
 }

--- a/src/main/java/com/server/crews/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/server/crews/recruitment/repository/RecruitmentRepository.java
@@ -1,0 +1,9 @@
+package com.server.crews.recruitment.repository;
+
+import com.server.crews.recruitment.domain.Recruitment;
+import java.util.Optional;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface RecruitmentRepository extends MongoRepository<Recruitment, String> {
+    Optional<Recruitment> findBySecretCode(String code);
+}


### PR DESCRIPTION
## Description 📒

>Spring security를 사용하지 않고 애너테이션을 생성해서 인증 객체 Controller에서 주입 받도록 함

## To improve 💬

access token 재발급, 지원서 양식과 지원서 생성 서비스 로직 구현
