### PR TITLE
모집 마감 기능 구현

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/main/resources/config"]
 	path = src/main/resources/config
-	url = https://github.com/Crews-Server/crews-config.git
+	url = https://github.com/team-crews/crews-config

--- a/src/main/java/com/server/crews/CrewsApplication.java
+++ b/src/main/java/com/server/crews/CrewsApplication.java
@@ -1,7 +1,5 @@
 package com.server.crews;
 
-import jakarta.annotation.PostConstruct;
-import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -12,10 +10,5 @@ public class CrewsApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(CrewsApplication.class, args);
-    }
-
-    @PostConstruct
-    public void init() {
-        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
     }
 }

--- a/src/main/java/com/server/crews/CrewsApplication.java
+++ b/src/main/java/com/server/crews/CrewsApplication.java
@@ -4,7 +4,9 @@ import jakarta.annotation.PostConstruct;
 import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class CrewsApplication {
 

--- a/src/main/java/com/server/crews/applicant/repository/ApplicationRepository.java
+++ b/src/main/java/com/server/crews/applicant/repository/ApplicationRepository.java
@@ -2,6 +2,7 @@ package com.server.crews.applicant.repository;
 
 import com.server.crews.applicant.domain.Application;
 import com.server.crews.recruitment.domain.Recruitment;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,4 +15,10 @@ public interface ApplicationRepository extends JpaRepository<Application, Long>,
             where recruitment = :recruitment
             """)
     int countAllByRecruitment(@Param("recruitment") Recruitment recruitment);
+
+    @Query("""
+            select a from Application a
+            where a.applicant.id = :applicantId
+            """)
+    Optional<Application> findByApplicantId(@Param("applicantId") Long applicantId);
 }

--- a/src/main/java/com/server/crews/auth/application/AuthService.java
+++ b/src/main/java/com/server/crews/auth/application/AuthService.java
@@ -45,13 +45,7 @@ public class AuthService {
 
     private Progress determineProgress(Administrator administrator) {
         return recruitmentRepository.findByPublisher(administrator.getId())
-                .map(recruitment -> {
-                    if (recruitment.hasPassedDeadline()) {
-                        recruitment.close();
-                        return Progress.COMPLETION;
-                    }
-                    return recruitment.getProgress();
-                })
+                .map(Recruitment::getProgress)
                 .orElse(Progress.READY);
     }
 
@@ -65,15 +59,8 @@ public class AuthService {
         Applicant applicant = applicantRepository.findByEmailAndRecruitment(email, recruitment)
                 .orElseGet(() -> createApplicant(email, password, recruitment));
         String accessToken = jwtTokenProvider.createAccessToken(Role.APPLICANT, email);
-        Progress progress = determineProgress(recruitment);
+        Progress progress = recruitment.getProgress();
         return new LoginResponse(applicant.getId(), accessToken, progress);
-    }
-
-    private Progress determineProgress(Recruitment recruitment) {
-        if (recruitment.hasPassedDeadline()) {
-            return Progress.COMPLETION;
-        }
-        return Progress.IN_PROGRESS;
     }
 
     private Applicant createApplicant(String email, String password, Recruitment recruitment) {

--- a/src/main/java/com/server/crews/auth/application/AuthService.java
+++ b/src/main/java/com/server/crews/auth/application/AuthService.java
@@ -11,7 +11,7 @@ import com.server.crews.auth.repository.AdministratorRepository;
 import com.server.crews.auth.repository.ApplicantRepository;
 import com.server.crews.global.exception.CrewsException;
 import com.server.crews.global.exception.ErrorCode;
-import com.server.crews.recruitment.domain.Progress;
+import com.server.crews.recruitment.domain.RecruitmentProgress;
 import com.server.crews.recruitment.domain.Recruitment;
 import com.server.crews.recruitment.repository.RecruitmentRepository;
 import lombok.RequiredArgsConstructor;
@@ -34,8 +34,8 @@ public class AuthService {
         Administrator administrator = administratorRepository.findByClubName(clubName)
                 .orElseGet(() -> createAdmin(clubName, password));
         String accessToken = jwtTokenProvider.createAccessToken(Role.ADMIN, clubName);
-        Progress progress = determineProgress(administrator);
-        return new LoginResponse(administrator.getId(), accessToken, progress);
+        RecruitmentProgress recruitmentProgress = determineProgress(administrator);
+        return new LoginResponse(administrator.getId(), accessToken, recruitmentProgress);
     }
 
     private Administrator createAdmin(String clubName, String password) {
@@ -43,10 +43,10 @@ public class AuthService {
         return administratorRepository.save(administrator);
     }
 
-    private Progress determineProgress(Administrator administrator) {
+    private RecruitmentProgress determineProgress(Administrator administrator) {
         return recruitmentRepository.findByPublisher(administrator.getId())
-                .map(Recruitment::getProgress)
-                .orElse(Progress.READY);
+                .map(Recruitment::getRecruitmentProgress)
+                .orElse(RecruitmentProgress.READY);
     }
 
     @Transactional
@@ -59,8 +59,8 @@ public class AuthService {
         Applicant applicant = applicantRepository.findByEmailAndRecruitment(email, recruitment)
                 .orElseGet(() -> createApplicant(email, password, recruitment));
         String accessToken = jwtTokenProvider.createAccessToken(Role.APPLICANT, email);
-        Progress progress = recruitment.getProgress();
-        return new LoginResponse(applicant.getId(), accessToken, progress);
+        RecruitmentProgress recruitmentProgress = recruitment.getRecruitmentProgress();
+        return new LoginResponse(applicant.getId(), accessToken, recruitmentProgress);
     }
 
     private Applicant createApplicant(String email, String password, Recruitment recruitment) {

--- a/src/main/java/com/server/crews/auth/application/AuthService.java
+++ b/src/main/java/com/server/crews/auth/application/AuthService.java
@@ -46,7 +46,7 @@ public class AuthService {
     private Progress determineProgress(Administrator administrator) {
         return recruitmentRepository.findByPublisher(administrator.getId())
                 .map(recruitment -> {
-                    if (recruitment.hasPassedClosingDate()) {
+                    if (recruitment.hasPassedDeadline()) {
                         recruitment.close();
                         return Progress.COMPLETION;
                     }
@@ -70,7 +70,7 @@ public class AuthService {
     }
 
     private Progress determineProgress(Recruitment recruitment) {
-        if (recruitment.hasPassedClosingDate()) {
+        if (recruitment.hasPassedDeadline()) {
             return Progress.COMPLETION;
         }
         return Progress.IN_PROGRESS;

--- a/src/main/java/com/server/crews/auth/application/AuthService.java
+++ b/src/main/java/com/server/crews/auth/application/AuthService.java
@@ -1,19 +1,23 @@
 package com.server.crews.auth.application;
 
+import com.server.crews.applicant.domain.Application;
+import com.server.crews.applicant.repository.ApplicationRepository;
 import com.server.crews.auth.domain.Administrator;
 import com.server.crews.auth.domain.Applicant;
 import com.server.crews.auth.domain.Role;
 import com.server.crews.auth.dto.LoginUser;
 import com.server.crews.auth.dto.request.AdminLoginRequest;
 import com.server.crews.auth.dto.request.ApplicantLoginRequest;
-import com.server.crews.auth.dto.response.LoginResponse;
+import com.server.crews.auth.dto.response.AdminLoginResponse;
+import com.server.crews.auth.dto.response.ApplicantLoginResponse;
 import com.server.crews.auth.repository.AdministratorRepository;
 import com.server.crews.auth.repository.ApplicantRepository;
 import com.server.crews.global.exception.CrewsException;
 import com.server.crews.global.exception.ErrorCode;
-import com.server.crews.recruitment.domain.RecruitmentProgress;
 import com.server.crews.recruitment.domain.Recruitment;
+import com.server.crews.recruitment.domain.RecruitmentProgress;
 import com.server.crews.recruitment.repository.RecruitmentRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,18 +28,22 @@ public class AuthService {
     private final AdministratorRepository administratorRepository;
     private final ApplicantRepository applicantRepository;
     private final RecruitmentRepository recruitmentRepository;
+    private final ApplicationRepository applicationRepository;
     private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
-    public LoginResponse loginForAdmin(AdminLoginRequest request) {
+    public AdminLoginResponse loginForAdmin(AdminLoginRequest request) {
         String clubName = request.clubName();
         String password = request.password();
 
         Administrator administrator = administratorRepository.findByClubName(clubName)
                 .orElseGet(() -> createAdmin(clubName, password));
         String accessToken = jwtTokenProvider.createAccessToken(Role.ADMIN, clubName);
-        RecruitmentProgress recruitmentProgress = determineProgress(administrator);
-        return new LoginResponse(administrator.getId(), accessToken, recruitmentProgress);
+        Optional<Recruitment> optionalRecruitment = recruitmentRepository.findByPublisher(administrator.getId());
+        Long recruitmentId = optionalRecruitment.map(Recruitment::getId).orElse(null);
+        RecruitmentProgress recruitmentProgress = optionalRecruitment.map(Recruitment::getRecruitmentProgress)
+                .orElse(RecruitmentProgress.READY);
+        return new AdminLoginResponse(administrator.getId(), accessToken, recruitmentProgress, recruitmentId);
     }
 
     private Administrator createAdmin(String clubName, String password) {
@@ -43,14 +51,8 @@ public class AuthService {
         return administratorRepository.save(administrator);
     }
 
-    private RecruitmentProgress determineProgress(Administrator administrator) {
-        return recruitmentRepository.findByPublisher(administrator.getId())
-                .map(Recruitment::getRecruitmentProgress)
-                .orElse(RecruitmentProgress.READY);
-    }
-
     @Transactional
-    public LoginResponse loginForApplicant(ApplicantLoginRequest request) {
+    public ApplicantLoginResponse loginForApplicant(ApplicantLoginRequest request) {
         String email = request.email();
         String password = request.password();
         Recruitment recruitment = recruitmentRepository.findByCode(request.recruitmentCode())
@@ -58,9 +60,12 @@ public class AuthService {
 
         Applicant applicant = applicantRepository.findByEmailAndRecruitment(email, recruitment)
                 .orElseGet(() -> createApplicant(email, password, recruitment));
+        Long applicationId = applicationRepository.findByApplicantId(applicant.getId())
+                .map(Application::getId)
+                .orElse(null);
         String accessToken = jwtTokenProvider.createAccessToken(Role.APPLICANT, email);
         RecruitmentProgress recruitmentProgress = recruitment.getRecruitmentProgress();
-        return new LoginResponse(applicant.getId(), accessToken, recruitmentProgress);
+        return new ApplicantLoginResponse(applicant.getId(), accessToken, recruitmentProgress, applicationId);
     }
 
     private Applicant createApplicant(String email, String password, Recruitment recruitment) {

--- a/src/main/java/com/server/crews/auth/application/RefreshTokenService.java
+++ b/src/main/java/com/server/crews/auth/application/RefreshTokenService.java
@@ -3,7 +3,7 @@ package com.server.crews.auth.application;
 import com.server.crews.auth.domain.RefreshToken;
 import com.server.crews.auth.domain.Role;
 import com.server.crews.auth.dto.RefreshTokenWithValidity;
-import com.server.crews.auth.dto.response.LoginResponse;
+import com.server.crews.auth.dto.response.TokenRefreshResponse;
 import com.server.crews.auth.repository.RefreshTokenRepository;
 import com.server.crews.global.exception.CrewsException;
 import com.server.crews.global.exception.ErrorCode;
@@ -34,15 +34,14 @@ public class RefreshTokenService {
         return new RefreshTokenWithValidity(refreshTokenValidityInSecond, refreshToken);
     }
 
-    public LoginResponse renew(String refreshToken) {
+    public TokenRefreshResponse renew(String refreshToken) {
         jwtTokenProvider.validateRefreshToken(refreshToken);
         refreshTokenRepository.findByToken(refreshToken)
                 .orElseThrow(() -> new CrewsException(ErrorCode.INVALID_REFRESH_TOKEN));
 
         String payload = jwtTokenProvider.getPayload(refreshToken);
-        long id = Long.parseLong(payload);
         Role role = jwtTokenProvider.getRole(refreshToken);
         String accessToken = jwtTokenProvider.createAccessToken(role, payload);
-        return new LoginResponse(id, accessToken, null);
+        return new TokenRefreshResponse(accessToken);
     }
 }

--- a/src/main/java/com/server/crews/auth/dto/response/AdminLoginResponse.java
+++ b/src/main/java/com/server/crews/auth/dto/response/AdminLoginResponse.java
@@ -1,0 +1,11 @@
+package com.server.crews.auth.dto.response;
+
+import com.server.crews.recruitment.domain.RecruitmentProgress;
+
+public record AdminLoginResponse(
+        Long adminId,
+        String accessToken,
+        RecruitmentProgress recruitmentProgress,
+        Long recruitmentId
+) {
+}

--- a/src/main/java/com/server/crews/auth/dto/response/ApplicantLoginResponse.java
+++ b/src/main/java/com/server/crews/auth/dto/response/ApplicantLoginResponse.java
@@ -1,0 +1,11 @@
+package com.server.crews.auth.dto.response;
+
+import com.server.crews.recruitment.domain.RecruitmentProgress;
+
+public record ApplicantLoginResponse(
+        Long applicantId,
+        String accessToken,
+        RecruitmentProgress recruitmentProgress,
+        Long applicationId
+) {
+}

--- a/src/main/java/com/server/crews/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/server/crews/auth/dto/response/LoginResponse.java
@@ -1,6 +1,6 @@
 package com.server.crews.auth.dto.response;
 
-import com.server.crews.recruitment.domain.Progress;
+import com.server.crews.recruitment.domain.RecruitmentProgress;
 
-public record LoginResponse(Long userId, String accessToken, Progress progress) {
+public record LoginResponse(Long userId, String accessToken, RecruitmentProgress recruitmentProgress) {
 }

--- a/src/main/java/com/server/crews/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/server/crews/auth/dto/response/LoginResponse.java
@@ -1,6 +1,0 @@
-package com.server.crews.auth.dto.response;
-
-import com.server.crews.recruitment.domain.RecruitmentProgress;
-
-public record LoginResponse(Long userId, String accessToken, RecruitmentProgress recruitmentProgress) {
-}

--- a/src/main/java/com/server/crews/auth/dto/response/TokenRefreshResponse.java
+++ b/src/main/java/com/server/crews/auth/dto/response/TokenRefreshResponse.java
@@ -1,0 +1,4 @@
+package com.server.crews.auth.dto.response;
+
+public record TokenRefreshResponse(String accessToken) {
+}

--- a/src/main/java/com/server/crews/auth/presentation/AuthController.java
+++ b/src/main/java/com/server/crews/auth/presentation/AuthController.java
@@ -6,7 +6,9 @@ import com.server.crews.auth.domain.Role;
 import com.server.crews.auth.dto.RefreshTokenWithValidity;
 import com.server.crews.auth.dto.request.AdminLoginRequest;
 import com.server.crews.auth.dto.request.ApplicantLoginRequest;
-import com.server.crews.auth.dto.response.LoginResponse;
+import com.server.crews.auth.dto.response.AdminLoginResponse;
+import com.server.crews.auth.dto.response.ApplicantLoginResponse;
+import com.server.crews.auth.dto.response.TokenRefreshResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -29,10 +31,10 @@ public class AuthController {
      * [동아리 관리자] 로그인 해 토큰을 발급 받는다. 모집 공고가 존재하지 않는다면 모집 공고를 새로 생성한다.
      */
     @PostMapping("/admin/login")
-    public ResponseEntity<LoginResponse> loginForAdmin(@RequestBody AdminLoginRequest request) {
-        LoginResponse loginResponse = authService.loginForAdmin(request);
+    public ResponseEntity<AdminLoginResponse> loginForAdmin(@RequestBody AdminLoginRequest request) {
+        AdminLoginResponse loginResponse = authService.loginForAdmin(request);
         RefreshTokenWithValidity refreshTokenWithValidity = refreshTokenService.createRefreshToken(Role.ADMIN,
-                loginResponse.userId());
+                loginResponse.adminId());
         ResponseCookie cookie = refreshTokenWithValidity.toCookie();
         return ResponseEntity.status(HttpStatus.OK)
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
@@ -43,10 +45,10 @@ public class AuthController {
      * [지원자] 로그인 해 토큰을 발급 받는다.
      */
     @PostMapping("/applicant/login")
-    public ResponseEntity<LoginResponse> loginForApplicant(@RequestBody ApplicantLoginRequest request) {
-        LoginResponse loginResponse = authService.loginForApplicant(request);
+    public ResponseEntity<ApplicantLoginResponse> loginForApplicant(@RequestBody ApplicantLoginRequest request) {
+        ApplicantLoginResponse loginResponse = authService.loginForApplicant(request);
         RefreshTokenWithValidity refreshTokenWithValidity = refreshTokenService.createRefreshToken(Role.APPLICANT,
-                loginResponse.userId());
+                loginResponse.applicantId());
         ResponseCookie cookie = refreshTokenWithValidity.toCookie();
         return ResponseEntity.status(HttpStatus.OK)
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
@@ -57,7 +59,7 @@ public class AuthController {
      * access token을 재발급 받는다.
      */
     @PostMapping("/refresh")
-    public ResponseEntity<LoginResponse> renew(@CookieValue("refreshToken") String refreshToken) {
+    public ResponseEntity<TokenRefreshResponse> renew(@CookieValue("refreshToken") String refreshToken) {
         return ResponseEntity.ok(refreshTokenService.renew(refreshToken));
     }
 }

--- a/src/main/java/com/server/crews/global/config/ClockConfig.java
+++ b/src/main/java/com/server/crews/global/config/ClockConfig.java
@@ -1,0 +1,15 @@
+package com.server.crews.global.config;
+
+import java.time.Clock;
+import java.time.ZoneId;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ClockConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.system(ZoneId.of("Asia/Seoul"));
+    }
+}

--- a/src/main/java/com/server/crews/global/exception/ErrorCode.java
+++ b/src/main/java/com/server/crews/global/exception/ErrorCode.java
@@ -10,7 +10,7 @@ public enum ErrorCode {
     DUPLICATE_SECRET_CODE(HttpStatus.BAD_REQUEST, "중복된 코드입니다."),
     NO_PARAMETER(HttpStatus.BAD_REQUEST, "%s 파라미터가 없습니다."),
     INVALID_EMAIL_PATTERN(HttpStatus.BAD_REQUEST, "유효하지 않은 이메일 형식입니다."),
-    INVALID_CLOSING_DATE(HttpStatus.BAD_REQUEST, "모집 마감일은 지금 이전이 될 수 없습니다."),
+    INVALID_DEADLINE(HttpStatus.BAD_REQUEST, "모집 마감 기한은 현재 시각 이전이며 한 시간 단위입니다."),
     ALREADY_ANNOUNCED(HttpStatus.BAD_REQUEST, "모집 공고 결과 발표가 이미 완료되었습니다."),
     RECRUITMENT_ALREADY_STARTED(HttpStatus.BAD_REQUEST, "모집이 이미 시작되었습니다."),
     DUPLICATE_NARRATIVE_ANSWERS(HttpStatus.BAD_REQUEST, "같은 서술형 문항에 대해 여러 답변이 존재할 수 없습니다."),

--- a/src/main/java/com/server/crews/recruitment/application/RecruitmentService.java
+++ b/src/main/java/com/server/crews/recruitment/application/RecruitmentService.java
@@ -13,7 +13,7 @@ import com.server.crews.recruitment.domain.NarrativeQuestion;
 import com.server.crews.recruitment.domain.Recruitment;
 import com.server.crews.recruitment.domain.Section;
 import com.server.crews.recruitment.domain.SelectiveQuestion;
-import com.server.crews.recruitment.dto.request.ClosingDateUpdateRequest;
+import com.server.crews.recruitment.dto.request.DeadlineUpdateRequest;
 import com.server.crews.recruitment.dto.request.RecruitmentSaveRequest;
 import com.server.crews.recruitment.dto.response.RecruitmentDetailsResponse;
 import com.server.crews.recruitment.dto.response.RecruitmentStateInProgressResponse;
@@ -65,7 +65,7 @@ public class RecruitmentService {
         Recruitment recruitment = recruitmentRepository.findByPublisher(publisherId)
                 .orElseThrow(() -> new CrewsException(ErrorCode.RECRUITMENT_NOT_FOUND));
         int applicationCount = applicationRepository.countAllByRecruitment(recruitment);
-        return new RecruitmentStateInProgressResponse(applicationCount, recruitment.getClosingDate());
+        return new RecruitmentStateInProgressResponse(applicationCount, recruitment.getDeadline());
     }
 
     public RecruitmentDetailsResponse findRecruitmentDetailsById(Long recruitmentId) {
@@ -93,11 +93,11 @@ public class RecruitmentService {
     }
 
     @Transactional
-    public void updateClosingDate(Long publisherId, ClosingDateUpdateRequest request) {
+    public void updateDeadline(Long publisherId, DeadlineUpdateRequest request) {
         Recruitment recruitment = recruitmentRepository.findByPublisher(publisherId)
                 .orElseThrow(() -> new CrewsException(ErrorCode.RECRUITMENT_NOT_FOUND));
-        LocalDateTime closingDate = LocalDateTime.parse(request.closingDate());
-        recruitment.updateClosingDate(closingDate);
+        LocalDateTime deadline = LocalDateTime.parse(request.deadline());
+        recruitment.updateDeadline(deadline);
     }
 
     @Transactional

--- a/src/main/java/com/server/crews/recruitment/application/RecruitmentService.java
+++ b/src/main/java/com/server/crews/recruitment/application/RecruitmentService.java
@@ -20,6 +20,7 @@ import com.server.crews.recruitment.dto.response.RecruitmentStateInProgressRespo
 import com.server.crews.recruitment.repository.NarrativeQuestionRepository;
 import com.server.crews.recruitment.repository.RecruitmentRepository;
 import com.server.crews.recruitment.repository.SelectiveQuestionRepository;
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +43,7 @@ public class RecruitmentService {
     private final AdministratorRepository administratorRepository;
     private final ApplicationRepository applicationRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final Clock clock;
 
     @Transactional
     public RecruitmentDetailsResponse saveRecruitment(Long publisherId, RecruitmentSaveRequest request) {
@@ -104,7 +106,7 @@ public class RecruitmentService {
     @Transactional
     @Scheduled(cron = "${schedules.cron.closing-recruitment}")
     public void closeRecruitments() {
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = LocalDateTime.now(clock);
         List<Recruitment> recruitments = recruitmentRepository.findAll();
         recruitments.stream()
                 .filter(recruitment -> recruitment.hasPassedDeadline(now))

--- a/src/main/java/com/server/crews/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/server/crews/recruitment/domain/Recruitment.java
@@ -116,7 +116,7 @@ public class Recruitment {
         return this.progress != Progress.READY;
     }
 
-    public boolean hasPassedDeadline() {
-        return LocalDateTime.now().isAfter(deadline);
+    public boolean hasPassedDeadline(LocalDateTime now) {
+        return now.isAfter(deadline) || now.equals(deadline);
     }
 }

--- a/src/main/java/com/server/crews/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/server/crews/recruitment/domain/Recruitment.java
@@ -53,8 +53,8 @@ public class Recruitment {
     @Column(name = "progress", nullable = false)
     private Progress progress;
 
-    @Column(name = "closing_date", nullable = false)
-    private LocalDateTime closingDate;
+    @Column(name = "deadline", nullable = false)
+    private LocalDateTime deadline;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "publisher_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
@@ -64,22 +64,25 @@ public class Recruitment {
     @Column(name = "created_date", updatable = false, nullable = false)
     private LocalDateTime createdDate;
 
-    public Recruitment(Long id, String code, String title, String description, LocalDateTime closingDate,
+    public Recruitment(Long id, String code, String title, String description, LocalDateTime deadline,
                        Administrator publisher, List<Section> sections) {
-        validateClosingDate(closingDate);
+        validateDeadline(deadline);
         this.id = id;
         this.code = code;
         this.title = title;
         this.description = description;
-        this.closingDate = closingDate;
+        this.deadline = deadline;
         this.publisher = publisher;
         this.progress = Progress.READY;
         addSections(sections);
     }
 
-    private void validateClosingDate(LocalDateTime closingDate) {
-        if (closingDate.isBefore(LocalDateTime.now())) {
-            throw new CrewsException(ErrorCode.INVALID_CLOSING_DATE);
+    private void validateDeadline(LocalDateTime deadline) {
+        if (deadline.isBefore(LocalDateTime.now())) {
+            throw new CrewsException(ErrorCode.INVALID_DEADLINE);
+        }
+        if (deadline.getMinute() != 0 || deadline.getSecond() != 0 || deadline.getNano() != 0) {
+            throw new CrewsException(ErrorCode.INVALID_DEADLINE);
         }
     }
 
@@ -100,9 +103,9 @@ public class Recruitment {
         this.progress = Progress.COMPLETION;
     }
 
-    public void updateClosingDate(LocalDateTime closingDate) {
-        validateClosingDate(closingDate);
-        this.closingDate = closingDate;
+    public void updateDeadline(LocalDateTime deadline) {
+        validateDeadline(deadline);
+        this.deadline = deadline;
     }
 
     public boolean isAnnounced() {
@@ -113,7 +116,7 @@ public class Recruitment {
         return this.progress != Progress.READY;
     }
 
-    public boolean hasPassedClosingDate() {
-        return LocalDateTime.now().isAfter(closingDate);
+    public boolean hasPassedDeadline() {
+        return LocalDateTime.now().isAfter(deadline);
     }
 }

--- a/src/main/java/com/server/crews/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/server/crews/recruitment/domain/Recruitment.java
@@ -53,7 +53,7 @@ public class Recruitment {
     private String description;
 
     @Column(name = "progress", nullable = false)
-    private Progress progress;
+    private RecruitmentProgress recruitmentProgress;
 
     @Column(name = "deadline", nullable = false)
     private LocalDateTime deadline;
@@ -75,7 +75,7 @@ public class Recruitment {
         this.description = description;
         this.deadline = deadline;
         this.publisher = publisher;
-        this.progress = Progress.READY;
+        this.recruitmentProgress = RecruitmentProgress.READY;
         addSections(sections);
     }
 
@@ -95,15 +95,15 @@ public class Recruitment {
     }
 
     public void start() {
-        this.progress = Progress.IN_PROGRESS;
+        this.recruitmentProgress = RecruitmentProgress.IN_PROGRESS;
     }
 
     public void announce() {
-        this.progress = Progress.ANNOUNCED;
+        this.recruitmentProgress = RecruitmentProgress.ANNOUNCED;
     }
 
     public void close() {
-        this.progress = Progress.COMPLETION;
+        this.recruitmentProgress = RecruitmentProgress.COMPLETION;
     }
 
     public void updateDeadline(LocalDateTime deadline) {
@@ -112,11 +112,11 @@ public class Recruitment {
     }
 
     public boolean isAnnounced() {
-        return this.progress == Progress.ANNOUNCED;
+        return this.recruitmentProgress == RecruitmentProgress.ANNOUNCED;
     }
 
     public boolean isStarted() {
-        return this.progress != Progress.READY;
+        return this.recruitmentProgress != RecruitmentProgress.READY;
     }
 
     public boolean hasPassedDeadline(LocalDateTime now) {

--- a/src/main/java/com/server/crews/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/server/crews/recruitment/domain/Recruitment.java
@@ -17,7 +17,9 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.time.Clock;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -78,7 +80,8 @@ public class Recruitment {
     }
 
     private void validateDeadline(LocalDateTime deadline) {
-        if (deadline.isBefore(LocalDateTime.now())) {
+        LocalDateTime now = LocalDateTime.now(Clock.system(ZoneId.of("Asia/Seoul")));
+        if (deadline.isBefore(now)) {
             throw new CrewsException(ErrorCode.INVALID_DEADLINE);
         }
         if (deadline.getMinute() != 0 || deadline.getSecond() != 0 || deadline.getNano() != 0) {

--- a/src/main/java/com/server/crews/recruitment/domain/RecruitmentProgress.java
+++ b/src/main/java/com/server/crews/recruitment/domain/RecruitmentProgress.java
@@ -1,6 +1,6 @@
 package com.server.crews.recruitment.domain;
 
-public enum Progress {
+public enum RecruitmentProgress {
     READY, // 모집 공고 작성 중
     IN_PROGRESS, // 모집 중
     COMPLETION, // 모집 완료 (평가 중)

--- a/src/main/java/com/server/crews/recruitment/dto/request/DeadlineUpdateRequest.java
+++ b/src/main/java/com/server/crews/recruitment/dto/request/DeadlineUpdateRequest.java
@@ -2,11 +2,10 @@ package com.server.crews.recruitment.dto.request;
 
 import com.server.crews.recruitment.presentation.DateTimeFormat;
 import jakarta.validation.constraints.NotNull;
-import java.time.LocalDateTime;
 
-public record ClosingDateUpdateRequest(
+public record DeadlineUpdateRequest(
         @NotNull(message = "모집 마감일은 null일 수 없습니다.")
         @DateTimeFormat
-        String closingDate
+        String deadline
 ) {
 }

--- a/src/main/java/com/server/crews/recruitment/dto/request/RecruitmentSaveRequest.java
+++ b/src/main/java/com/server/crews/recruitment/dto/request/RecruitmentSaveRequest.java
@@ -17,13 +17,13 @@ public record RecruitmentSaveRequest(
         String description,
         @Valid
         List<SectionSaveRequest> sections,
-        @NotNull(message = "모집 마감일은 null일 수 없습니다.")
+        @NotNull(message = "모집 마감 기한은 null일 수 없습니다.")
         @DateTimeFormat
-        String closingDate
+        String deadline
 ) {
     public Recruitment toRecruitment(String code, Administrator publisher) {
-        LocalDateTime closingDateTime = LocalDateTime.parse(closingDate);
-        return new Recruitment(id, code, title, description, closingDateTime, publisher, toSections());
+        LocalDateTime deadlineDateTime = LocalDateTime.parse(deadline);
+        return new Recruitment(id, code, title, description, deadlineDateTime, publisher, toSections());
     }
 
     public List<Section> toSections() {

--- a/src/main/java/com/server/crews/recruitment/dto/response/RecruitmentDetailsResponse.java
+++ b/src/main/java/com/server/crews/recruitment/dto/response/RecruitmentDetailsResponse.java
@@ -1,7 +1,7 @@
 package com.server.crews.recruitment.dto.response;
 
 import com.server.crews.recruitment.domain.NarrativeQuestion;
-import com.server.crews.recruitment.domain.Progress;
+import com.server.crews.recruitment.domain.RecruitmentProgress;
 import com.server.crews.recruitment.domain.Recruitment;
 import com.server.crews.recruitment.domain.Section;
 import com.server.crews.recruitment.domain.SelectiveQuestion;
@@ -11,12 +11,12 @@ import java.util.List;
 import java.util.Map;
 
 public record RecruitmentDetailsResponse(
-        Long id, String title, String description, Progress progress, List<SectionResponse> sections,
+        Long id, String title, String description, RecruitmentProgress recruitmentProgress, List<SectionResponse> sections,
         LocalDateTime deadline, String code) {
 
     public static RecruitmentDetailsResponse from(Recruitment recruitment) {
         return new RecruitmentDetailsResponse(recruitment.getId(), recruitment.getTitle(), recruitment.getDescription(),
-                recruitment.getProgress(), sectionResponses(recruitment.getSections()), recruitment.getDeadline(),
+                recruitment.getRecruitmentProgress(), sectionResponses(recruitment.getSections()), recruitment.getDeadline(),
                 recruitment.getCode());
     }
 
@@ -32,7 +32,7 @@ public record RecruitmentDetailsResponse(
         List<SectionResponse> sectionResponses = sectionResponses(recruitment.getSections(),
                 narrativeQuestionsBySection, selectiveQuestionsBySection);
         return new RecruitmentDetailsResponse(recruitment.getId(), recruitment.getTitle(), recruitment.getDescription(),
-                recruitment.getProgress(), sectionResponses, recruitment.getDeadline(), recruitment.getCode());
+                recruitment.getRecruitmentProgress(), sectionResponses, recruitment.getDeadline(), recruitment.getCode());
     }
 
     private static List<SectionResponse> sectionResponses(

--- a/src/main/java/com/server/crews/recruitment/dto/response/RecruitmentDetailsResponse.java
+++ b/src/main/java/com/server/crews/recruitment/dto/response/RecruitmentDetailsResponse.java
@@ -12,11 +12,11 @@ import java.util.Map;
 
 public record RecruitmentDetailsResponse(
         Long id, String title, String description, Progress progress, List<SectionResponse> sections,
-        LocalDateTime closingDate, String code) {
+        LocalDateTime deadline, String code) {
 
     public static RecruitmentDetailsResponse from(Recruitment recruitment) {
         return new RecruitmentDetailsResponse(recruitment.getId(), recruitment.getTitle(), recruitment.getDescription(),
-                recruitment.getProgress(), sectionResponses(recruitment.getSections()), recruitment.getClosingDate(),
+                recruitment.getProgress(), sectionResponses(recruitment.getSections()), recruitment.getDeadline(),
                 recruitment.getCode());
     }
 
@@ -32,7 +32,7 @@ public record RecruitmentDetailsResponse(
         List<SectionResponse> sectionResponses = sectionResponses(recruitment.getSections(),
                 narrativeQuestionsBySection, selectiveQuestionsBySection);
         return new RecruitmentDetailsResponse(recruitment.getId(), recruitment.getTitle(), recruitment.getDescription(),
-                recruitment.getProgress(), sectionResponses, recruitment.getClosingDate(), recruitment.getCode());
+                recruitment.getProgress(), sectionResponses, recruitment.getDeadline(), recruitment.getCode());
     }
 
     private static List<SectionResponse> sectionResponses(

--- a/src/main/java/com/server/crews/recruitment/dto/response/RecruitmentStateInProgressResponse.java
+++ b/src/main/java/com/server/crews/recruitment/dto/response/RecruitmentStateInProgressResponse.java
@@ -2,5 +2,5 @@ package com.server.crews.recruitment.dto.response;
 
 import java.time.LocalDateTime;
 
-public record RecruitmentStateInProgressResponse(int applicationCount, LocalDateTime closingDate) {
+public record RecruitmentStateInProgressResponse(int applicationCount, LocalDateTime deadline) {
 }

--- a/src/main/java/com/server/crews/recruitment/presentation/RecruitmentController.java
+++ b/src/main/java/com/server/crews/recruitment/presentation/RecruitmentController.java
@@ -3,7 +3,7 @@ package com.server.crews.recruitment.presentation;
 import com.server.crews.auth.dto.LoginUser;
 import com.server.crews.auth.presentation.AdminAuthentication;
 import com.server.crews.recruitment.application.RecruitmentService;
-import com.server.crews.recruitment.dto.request.ClosingDateUpdateRequest;
+import com.server.crews.recruitment.dto.request.DeadlineUpdateRequest;
 import com.server.crews.recruitment.dto.request.RecruitmentSaveRequest;
 import com.server.crews.recruitment.dto.response.RecruitmentDetailsResponse;
 import com.server.crews.recruitment.dto.response.RecruitmentStateInProgressResponse;
@@ -75,11 +75,11 @@ public class RecruitmentController {
     /**
      * 모집 마감기한을 변경한다.
      */
-    @PatchMapping("/closing-date")
-    public ResponseEntity<Void> updateClosingDate(
+    @PatchMapping("/deadline")
+    public ResponseEntity<Void> updateDeadline(
             @AdminAuthentication LoginUser loginUser,
-            @RequestBody ClosingDateUpdateRequest request) {
-        recruitmentService.updateClosingDate(loginUser.userId(), request);
+            @RequestBody DeadlineUpdateRequest request) {
+        recruitmentService.updateDeadline(loginUser.userId(), request);
         return ResponseEntity.ok().build();
     }
 

--- a/src/test/java/com/server/crews/api/ApiTest.java
+++ b/src/test/java/com/server/crews/api/ApiTest.java
@@ -13,7 +13,8 @@ import com.server.crews.applicant.dto.request.ApplicationSaveRequest;
 import com.server.crews.applicant.dto.response.ApplicationDetailsResponse;
 import com.server.crews.auth.dto.request.AdminLoginRequest;
 import com.server.crews.auth.dto.request.ApplicantLoginRequest;
-import com.server.crews.auth.dto.response.LoginResponse;
+import com.server.crews.auth.dto.response.AdminLoginResponse;
+import com.server.crews.auth.dto.response.ApplicantLoginResponse;
 import com.server.crews.auth.presentation.AuthorizationExtractor;
 import com.server.crews.environ.DatabaseCleaner;
 import com.server.crews.external.application.EmailService;
@@ -70,7 +71,7 @@ public abstract class ApiTest {
                 answerSaveRequests);
     }
 
-    protected LoginResponse signUpAdmin(String clubName, String password) {
+    protected AdminLoginResponse signUpAdmin(String clubName, String password) {
         ExtractableResponse<Response> response = RestAssured.given()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(new AdminLoginRequest(clubName, password))
@@ -78,7 +79,7 @@ public abstract class ApiTest {
                 .then()
                 .statusCode(HttpStatus.OK.value())
                 .extract();
-        return response.as(LoginResponse.class);
+        return response.as(AdminLoginResponse.class);
     }
 
     protected RecruitmentDetailsResponse createRecruitment(String accessToken) {
@@ -97,7 +98,7 @@ public abstract class ApiTest {
         return response.as(RecruitmentDetailsResponse.class);
     }
 
-    protected LoginResponse signUpApplicant(String recruitmentCode, String email, String password) {
+    protected ApplicantLoginResponse signUpApplicant(String recruitmentCode, String email, String password) {
         ExtractableResponse<Response> response = RestAssured.given()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(new ApplicantLoginRequest(recruitmentCode, email, password))
@@ -105,7 +106,7 @@ public abstract class ApiTest {
                 .then()
                 .statusCode(HttpStatus.OK.value())
                 .extract();
-        return response.as(LoginResponse.class);
+        return response.as(ApplicantLoginResponse.class);
     }
 
     protected ApplicationDetailsResponse createTestApplication(String accessToken,

--- a/src/test/java/com/server/crews/api/ApplicationApiTest.java
+++ b/src/test/java/com/server/crews/api/ApplicationApiTest.java
@@ -19,7 +19,8 @@ import com.server.crews.applicant.dto.response.ApplicationDetailsResponse;
 import com.server.crews.applicant.dto.response.ApplicationsResponse;
 import com.server.crews.applicant.dto.response.NarrativeAnswerResponse;
 import com.server.crews.applicant.dto.response.SelectiveAnswerResponse;
-import com.server.crews.auth.dto.response.LoginResponse;
+import com.server.crews.auth.dto.response.AdminLoginResponse;
+import com.server.crews.auth.dto.response.ApplicantLoginResponse;
 import com.server.crews.auth.presentation.AuthorizationExtractor;
 import com.server.crews.recruitment.dto.request.QuestionType;
 import com.server.crews.recruitment.dto.response.RecruitmentDetailsResponse;
@@ -39,16 +40,16 @@ public class ApplicationApiTest extends ApiTest {
     @DisplayName("지원자가 로그인하여 지원서를 저장한다.")
     void saveApplication() {
         // given
-        LoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
+        AdminLoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
         RecruitmentDetailsResponse recruitmentDetailsResponse = createRecruitment(adminTokenResponse.accessToken());
-        LoginResponse applicantTokenResponse = signUpApplicant(recruitmentDetailsResponse.code(), TEST_EMAIL,
+        ApplicantLoginResponse applicantLoginResponse = signUpApplicant(recruitmentDetailsResponse.code(), TEST_EMAIL,
                 TEST_PASSWORD);
         List<AnswerSaveRequest> firstAnswerSaveRequests = List.of(
                 new AnswerSaveRequest(null, QuestionType.NARRATIVE.name(), 2L, DEFAULT_NARRATIVE_ANSWER, null),
                 new AnswerSaveRequest(null, QuestionType.SELECTIVE.name(), 1L, null, 2L));
         ApplicationSaveRequest applicationCreateRequest = new ApplicationSaveRequest(null, DEFAULT_STUDENT_NUMBER,
                 DEFAULT_MAJOR, DEFAULT_NAME, firstAnswerSaveRequests);
-        ApplicationDetailsResponse testApplication = createTestApplication(applicantTokenResponse.accessToken(),
+        ApplicationDetailsResponse testApplication = createTestApplication(applicantLoginResponse.accessToken(),
                 applicationCreateRequest);
 
         List<AnswerSaveRequest> secondAnswerSaveRequests = List.of(
@@ -63,7 +64,7 @@ public class ApplicationApiTest extends ApiTest {
                 .filter(ApplicationApiDocuments.SAVE_APPLICATION_200_DOCUMENT())
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.AUTHORIZATION,
-                        AuthorizationExtractor.BEARER_TYPE + applicantTokenResponse.accessToken())
+                        AuthorizationExtractor.BEARER_TYPE + applicantLoginResponse.accessToken())
                 .body(applicationUpdateRequest)
                 .when().post("/applications")
                 .then().log().all()
@@ -85,9 +86,9 @@ public class ApplicationApiTest extends ApiTest {
     @DisplayName("존재하지 않는 질문에 대해 답변을 저장한다.")
     void saveApplicationWithNotExistingQuestion() {
         // given
-        LoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
+        AdminLoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
         RecruitmentDetailsResponse recruitmentDetailsResponse = createRecruitment(adminTokenResponse.accessToken());
-        LoginResponse applicantTokenResponse = signUpApplicant(recruitmentDetailsResponse.code(), TEST_EMAIL,
+        ApplicantLoginResponse applicantLoginResponse = signUpApplicant(recruitmentDetailsResponse.code(), TEST_EMAIL,
                 TEST_PASSWORD);
         List<AnswerSaveRequest> answerSaveRequests = List.of(
                 new AnswerSaveRequest(null, QuestionType.NARRATIVE.name(), 10L, DEFAULT_NARRATIVE_ANSWER, null));
@@ -99,7 +100,7 @@ public class ApplicationApiTest extends ApiTest {
                 .filter(ApplicationApiDocuments.SAVE_APPLICATION_404_DOCUMENT())
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.AUTHORIZATION,
-                        AuthorizationExtractor.BEARER_TYPE + applicantTokenResponse.accessToken())
+                        AuthorizationExtractor.BEARER_TYPE + applicantLoginResponse.accessToken())
                 .body(applicationSaveRequest)
                 .when().post("/applications")
                 .then().log().all()
@@ -113,9 +114,9 @@ public class ApplicationApiTest extends ApiTest {
     @DisplayName("한 서술형 문항에 두 개 이상의 답변을 저장한다.")
     void saveApplicationWithDuplicatedNarrativeAnswer() {
         // given
-        LoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
+        AdminLoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
         RecruitmentDetailsResponse recruitmentDetailsResponse = createRecruitment(adminTokenResponse.accessToken());
-        LoginResponse applicantTokenResponse = signUpApplicant(recruitmentDetailsResponse.code(), TEST_EMAIL,
+        ApplicantLoginResponse applicantLoginResponse = signUpApplicant(recruitmentDetailsResponse.code(), TEST_EMAIL,
                 TEST_PASSWORD);
         List<AnswerSaveRequest> answerSaveRequests = List.of(
                 new AnswerSaveRequest(null, QuestionType.NARRATIVE.name(), 1L, "동일한 내용", null),
@@ -128,7 +129,7 @@ public class ApplicationApiTest extends ApiTest {
                 .filter(ApplicationApiDocuments.SAVE_APPLICATION_400_DOCUMENT())
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.AUTHORIZATION,
-                        AuthorizationExtractor.BEARER_TYPE + applicantTokenResponse.accessToken())
+                        AuthorizationExtractor.BEARER_TYPE + applicantLoginResponse.accessToken())
                 .body(applicationSaveRequest)
                 .when().post("/applications")
                 .then().log().all()
@@ -142,13 +143,13 @@ public class ApplicationApiTest extends ApiTest {
     @DisplayName("지원서의 상세 정보를 조회한다.")
     void getApplicationDetails() {
         // given
-        LoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
+        AdminLoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
         RecruitmentDetailsResponse recruitmentDetailsResponse = createRecruitment(adminTokenResponse.accessToken());
-        LoginResponse applicantTokenResponse = signUpApplicant(recruitmentDetailsResponse.code(), TEST_EMAIL,
+        ApplicantLoginResponse applicantLoginResponse = signUpApplicant(recruitmentDetailsResponse.code(), TEST_EMAIL,
                 TEST_PASSWORD);
 
         ApplicationSaveRequest applicationSaveRequest = applicationSaveRequest();
-        ApplicationDetailsResponse testApplication = createTestApplication(applicantTokenResponse.accessToken(),
+        ApplicationDetailsResponse testApplication = createTestApplication(applicantLoginResponse.accessToken(),
                 applicationSaveRequest);
 
         // when
@@ -156,7 +157,7 @@ public class ApplicationApiTest extends ApiTest {
                 .filter(ApplicationApiDocuments.GET_APPLICATION_200_DOCUMENT())
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.AUTHORIZATION,
-                        AuthorizationExtractor.BEARER_TYPE + applicantTokenResponse.accessToken())
+                        AuthorizationExtractor.BEARER_TYPE + applicantLoginResponse.accessToken())
                 .pathParam("application-id", testApplication.id())
                 .when().get("/applications/{application-id}")
                 .then().log().all()
@@ -177,11 +178,11 @@ public class ApplicationApiTest extends ApiTest {
     @DisplayName("지원서들을 평가한다.")
     void evaluate() {
         // given
-        LoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
+        AdminLoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
         RecruitmentDetailsResponse recruitmentDetailsResponse = createRecruitment(adminTokenResponse.accessToken());
-        LoginResponse applicantATokenResponse = signUpApplicant(recruitmentDetailsResponse.code(),
+        ApplicantLoginResponse applicantATokenResponse = signUpApplicant(recruitmentDetailsResponse.code(),
                 "A" + TEST_EMAIL, TEST_PASSWORD);
-        LoginResponse applicantBTokenResponse = signUpApplicant(recruitmentDetailsResponse.code(),
+        ApplicantLoginResponse applicantBTokenResponse = signUpApplicant(recruitmentDetailsResponse.code(),
                 "B" + TEST_EMAIL, TEST_PASSWORD);
 
         ApplicationSaveRequest applicationSaveRequest = applicationSaveRequest();
@@ -210,11 +211,11 @@ public class ApplicationApiTest extends ApiTest {
     @DisplayName("한 공고의 모든 지원서 목록을 조회한다.")
     void getAllApplicationsByRecruitment() {
         // given
-        LoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
+        AdminLoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
         RecruitmentDetailsResponse recruitmentDetailsResponse = createRecruitment(adminTokenResponse.accessToken());
-        LoginResponse applicantATokenResponse = signUpApplicant(recruitmentDetailsResponse.code(),
+        ApplicantLoginResponse applicantATokenResponse = signUpApplicant(recruitmentDetailsResponse.code(),
                 "A" + TEST_EMAIL, TEST_PASSWORD);
-        LoginResponse applicantBTokenResponse = signUpApplicant(recruitmentDetailsResponse.code(),
+        ApplicantLoginResponse applicantBTokenResponse = signUpApplicant(recruitmentDetailsResponse.code(),
                 "B" + TEST_EMAIL, TEST_PASSWORD);
 
         ApplicationSaveRequest applicationSaveRequest = applicationSaveRequest();

--- a/src/test/java/com/server/crews/api/AuthApiDocuments.java
+++ b/src/test/java/com/server/crews/api/AuthApiDocuments.java
@@ -21,13 +21,15 @@ public class AuthApiDocuments {
                         fieldWithPath(".password")
                                 .description("비밀번호")),
                 responseFields(
-                        fieldWithPath(".userId")
+                        fieldWithPath(".adminId")
                                 .description("운영진 id"),
                         fieldWithPath(".accessToken")
                                 .description("access token"),
                         fieldWithPath(".recruitmentProgress")
                                 .description(
-                                        "모집 공고 상태 (READY: 모집 공고 작성 중, IN_PROGRESS: 모집 중, COMPLETION: 평가 중, ANNOUNCED: 이메일 전송 완료)")
+                                        "모집 공고 상태 (READY: 모집 공고 작성 중, IN_PROGRESS: 모집 중, COMPLETION: 평가 중, ANNOUNCED: 이메일 전송 완료)"),
+                        fieldWithPath(".recruitmentId")
+                                .description("모집 공고 id (없다면 null)")
                 ),
                 responseCookies(
                         cookieWithName("refreshToken")
@@ -45,12 +47,14 @@ public class AuthApiDocuments {
                         fieldWithPath(".password")
                                 .description("비밀번호")),
                 responseFields(
-                        fieldWithPath(".userId")
+                        fieldWithPath(".applicantId")
                                 .description("지원자 id"),
                         fieldWithPath(".accessToken")
                                 .description("access token"),
                         fieldWithPath(".recruitmentProgress")
-                                .description("모집 공고 상태 (IN_PROGRESS: 모집 중, COMPLETION: 평가 중)")
+                                .description("모집 공고 상태 (IN_PROGRESS: 모집 중, COMPLETION: 평가 중)"),
+                        fieldWithPath(".applicationId")
+                                .description("지원서 id (없다면 null)")
                 ),
                 responseCookies(
                         cookieWithName("refreshToken")

--- a/src/test/java/com/server/crews/api/AuthApiDocuments.java
+++ b/src/test/java/com/server/crews/api/AuthApiDocuments.java
@@ -25,7 +25,7 @@ public class AuthApiDocuments {
                                 .description("운영진 id"),
                         fieldWithPath(".accessToken")
                                 .description("access token"),
-                        fieldWithPath(".progress")
+                        fieldWithPath(".recruitmentProgress")
                                 .description(
                                         "모집 공고 상태 (READY: 모집 공고 작성 중, IN_PROGRESS: 모집 중, COMPLETION: 평가 중, ANNOUNCED: 이메일 전송 완료)")
                 ),
@@ -49,7 +49,7 @@ public class AuthApiDocuments {
                                 .description("지원자 id"),
                         fieldWithPath(".accessToken")
                                 .description("access token"),
-                        fieldWithPath(".progress")
+                        fieldWithPath(".recruitmentProgress")
                                 .description("모집 공고 상태 (IN_PROGRESS: 모집 중, COMPLETION: 평가 중)")
                 ),
                 responseCookies(

--- a/src/test/java/com/server/crews/api/AuthApiTest.java
+++ b/src/test/java/com/server/crews/api/AuthApiTest.java
@@ -11,7 +11,7 @@ import com.server.crews.auth.dto.request.AdminLoginRequest;
 import com.server.crews.auth.dto.request.ApplicantLoginRequest;
 import com.server.crews.auth.dto.response.LoginResponse;
 import com.server.crews.auth.presentation.AuthorizationExtractor;
-import com.server.crews.recruitment.domain.Progress;
+import com.server.crews.recruitment.domain.RecruitmentProgress;
 import com.server.crews.recruitment.dto.response.RecruitmentDetailsResponse;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -46,7 +46,7 @@ public class AuthApiTest extends ApiTest {
             checkStatusCode200(response, softAssertions);
             softAssertions.assertThat(loginResponse.accessToken()).isNotEmpty();
             softAssertions.assertThat(cookies.get("refreshToken")).isNotNull();
-            softAssertions.assertThat(loginResponse.progress()).isEqualTo(Progress.READY);
+            softAssertions.assertThat(loginResponse.recruitmentProgress()).isEqualTo(RecruitmentProgress.READY);
         });
     }
 
@@ -72,7 +72,7 @@ public class AuthApiTest extends ApiTest {
             checkStatusCode200(response, softAssertions);
             softAssertions.assertThat(loginResponse.accessToken()).isNotEmpty();
             softAssertions.assertThat(cookies.get("refreshToken")).isNotNull();
-            softAssertions.assertThat(loginResponse.progress()).isEqualTo(Progress.READY);
+            softAssertions.assertThat(loginResponse.recruitmentProgress()).isEqualTo(RecruitmentProgress.READY);
         });
     }
 
@@ -102,7 +102,7 @@ public class AuthApiTest extends ApiTest {
             checkStatusCode200(response, softAssertions);
             softAssertions.assertThat(loginResponse.accessToken()).isNotEmpty();
             softAssertions.assertThat(cookies.get("refreshToken")).isNotNull();
-            softAssertions.assertThat(loginResponse.progress()).isEqualTo(Progress.IN_PROGRESS);
+            softAssertions.assertThat(loginResponse.recruitmentProgress()).isEqualTo(RecruitmentProgress.READY);
         });
     }
 

--- a/src/test/java/com/server/crews/api/AuthApiTest.java
+++ b/src/test/java/com/server/crews/api/AuthApiTest.java
@@ -9,7 +9,8 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.server.crews.auth.dto.request.AdminLoginRequest;
 import com.server.crews.auth.dto.request.ApplicantLoginRequest;
-import com.server.crews.auth.dto.response.LoginResponse;
+import com.server.crews.auth.dto.response.AdminLoginResponse;
+import com.server.crews.auth.dto.response.ApplicantLoginResponse;
 import com.server.crews.auth.presentation.AuthorizationExtractor;
 import com.server.crews.recruitment.domain.RecruitmentProgress;
 import com.server.crews.recruitment.dto.response.RecruitmentDetailsResponse;
@@ -40,13 +41,13 @@ public class AuthApiTest extends ApiTest {
                 .extract();
 
         // then
-        LoginResponse loginResponse = response.as(LoginResponse.class);
+        AdminLoginResponse adminLoginResponse = response.as(AdminLoginResponse.class);
         Map<String, String> cookies = response.cookies();
         assertSoftly(softAssertions -> {
             checkStatusCode200(response, softAssertions);
-            softAssertions.assertThat(loginResponse.accessToken()).isNotEmpty();
+            softAssertions.assertThat(adminLoginResponse.accessToken()).isNotEmpty();
             softAssertions.assertThat(cookies.get("refreshToken")).isNotNull();
-            softAssertions.assertThat(loginResponse.recruitmentProgress()).isEqualTo(RecruitmentProgress.READY);
+            softAssertions.assertThat(adminLoginResponse.recruitmentProgress()).isEqualTo(RecruitmentProgress.READY);
         });
     }
 
@@ -66,13 +67,13 @@ public class AuthApiTest extends ApiTest {
                 .extract();
 
         // then
-        LoginResponse loginResponse = response.as(LoginResponse.class);
+        AdminLoginResponse adminLoginResponse = response.as(AdminLoginResponse.class);
         Map<String, String> cookies = response.cookies();
         assertSoftly(softAssertions -> {
             checkStatusCode200(response, softAssertions);
-            softAssertions.assertThat(loginResponse.accessToken()).isNotEmpty();
+            softAssertions.assertThat(adminLoginResponse.accessToken()).isNotEmpty();
             softAssertions.assertThat(cookies.get("refreshToken")).isNotNull();
-            softAssertions.assertThat(loginResponse.recruitmentProgress()).isEqualTo(RecruitmentProgress.READY);
+            softAssertions.assertThat(adminLoginResponse.recruitmentProgress()).isEqualTo(RecruitmentProgress.READY);
         });
     }
 
@@ -80,7 +81,7 @@ public class AuthApiTest extends ApiTest {
     @DisplayName("[지원자] 가입하지 않은 지원자가 로그인 해 토큰을 발급 받는다.")
     void loginNotSignedUpApplicant() {
         // given
-        LoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
+        AdminLoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
         RecruitmentDetailsResponse recruitmentDetailsResponse = createRecruitment(adminTokenResponse.accessToken());
 
         ApplicantLoginRequest applicantLoginRequest = new ApplicantLoginRequest(recruitmentDetailsResponse.code(),
@@ -96,13 +97,13 @@ public class AuthApiTest extends ApiTest {
                 .extract();
 
         // then
-        LoginResponse loginResponse = response.as(LoginResponse.class);
+        ApplicantLoginResponse applicantLoginResponse = response.as(ApplicantLoginResponse.class);
         Map<String, String> cookies = response.cookies();
         assertSoftly(softAssertions -> {
             checkStatusCode200(response, softAssertions);
-            softAssertions.assertThat(loginResponse.accessToken()).isNotEmpty();
+            softAssertions.assertThat(applicantLoginResponse.accessToken()).isNotEmpty();
             softAssertions.assertThat(cookies.get("refreshToken")).isNotNull();
-            softAssertions.assertThat(loginResponse.recruitmentProgress()).isEqualTo(RecruitmentProgress.READY);
+            softAssertions.assertThat(applicantLoginResponse.recruitmentProgress()).isEqualTo(RecruitmentProgress.READY);
         });
     }
 
@@ -110,9 +111,9 @@ public class AuthApiTest extends ApiTest {
     @DisplayName("[지원자] 지원자 권한으로 지원자 목록을 조회한다.")
     void authenticateAdminWithApplicantToken() {
         // given
-        LoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
+        AdminLoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
         RecruitmentDetailsResponse recruitmentDetailsResponse = createRecruitment(adminTokenResponse.accessToken());
-        LoginResponse applicantTokenResponse = signUpApplicant(recruitmentDetailsResponse.code(), TEST_EMAIL,
+        ApplicantLoginResponse applicantLoginResponse = signUpApplicant(recruitmentDetailsResponse.code(), TEST_EMAIL,
                 TEST_PASSWORD);
 
         // when
@@ -120,7 +121,7 @@ public class AuthApiTest extends ApiTest {
                 .filter(AuthApiDocuments.AUTHORIZE_401_DOCUMENT())
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.AUTHORIZATION,
-                        AuthorizationExtractor.BEARER_TYPE + applicantTokenResponse.accessToken())
+                        AuthorizationExtractor.BEARER_TYPE + applicantLoginResponse.accessToken())
                 .when().get("/applications?recruitment-id=" + recruitmentDetailsResponse.id())
                 .then().log().all()
                 .extract();
@@ -154,10 +155,10 @@ public class AuthApiTest extends ApiTest {
                 .extract();
 
         // then
-        LoginResponse loginResponse = response.as(LoginResponse.class);
+        AdminLoginResponse adminLoginResponse = response.as(AdminLoginResponse.class);
         assertSoftly(softAssertions -> {
             checkStatusCode200(response);
-            softAssertions.assertThat(loginResponse.accessToken()).isNotNull();
+            softAssertions.assertThat(adminLoginResponse.accessToken()).isNotNull();
         });
     }
 }

--- a/src/test/java/com/server/crews/api/RecruitmentApiDocuments.java
+++ b/src/test/java/com/server/crews/api/RecruitmentApiDocuments.java
@@ -27,7 +27,7 @@ public class RecruitmentApiDocuments {
                 fieldWithPath(".description")
                         .description("모집 공고 설명")
                         .optional(),
-                fieldWithPath(".closingDate")
+                fieldWithPath(".deadline")
                         .description("모집 마감일"),
                 fieldWithPath(".sections")
                         .description("섹션 목록")
@@ -81,7 +81,7 @@ public class RecruitmentApiDocuments {
                         fieldWithPath(".title").description("모집 공고 제목"),
                         fieldWithPath(".description").description("모집 공고 설명"),
                         fieldWithPath(".sections").description("섹션 목록"),
-                        fieldWithPath(".closingDate").description("현재 날짜 이후여야 하는 모집 마감일")));
+                        fieldWithPath(".deadline").description("현재 날짜 이후여야 하는 모집 마감일")));
     }
 
     public static RestDocumentationFilter START_RECRUITMENT_200_DOCUMENT() {
@@ -106,9 +106,9 @@ public class RecruitmentApiDocuments {
                 queryParameters(parameterWithName("code").description("모집 공고 코드")));
     }
 
-    public static RestDocumentationFilter UPDATE_RECRUITMENT_CLOSING_DATE_200_DOCUMENT() {
+    public static RestDocumentationFilter UPDATE_RECRUITMENT_DEADLINE_200_DOCUMENT() {
         return document(RECRUITMENT_API + "모집 마감일 변경",
-                requestFields(fieldWithPath(".closingDate").description("변경된 마감일")));
+                requestFields(fieldWithPath(".deadline").description("변경된 마감일")));
     }
 
     public static RestDocumentationFilter SEND_OUTCOME_EMAIL_200_REQUEST() {

--- a/src/test/java/com/server/crews/api/RecruitmentApiTest.java
+++ b/src/test/java/com/server/crews/api/RecruitmentApiTest.java
@@ -14,7 +14,8 @@ import static com.server.crews.fixture.UserFixture.TEST_PASSWORD;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.server.crews.applicant.dto.request.ApplicationSaveRequest;
-import com.server.crews.auth.dto.response.LoginResponse;
+import com.server.crews.auth.dto.response.AdminLoginResponse;
+import com.server.crews.auth.dto.response.ApplicantLoginResponse;
 import com.server.crews.auth.presentation.AuthorizationExtractor;
 import com.server.crews.recruitment.dto.request.ChoiceSaveRequest;
 import com.server.crews.recruitment.dto.request.DeadlineUpdateRequest;
@@ -44,7 +45,7 @@ public class RecruitmentApiTest extends ApiTest {
     @DisplayName("모집 공고를 저장한다.")
     void saveRecruitment() {
         // given
-        LoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
+        AdminLoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
         String accessToken = adminTokenResponse.accessToken();
         ChoiceSaveRequest choiceCreateRequest = new ChoiceSaveRequest(null, "선택지 내용");
         QuestionSaveRequest selectiveQuestionCreateRequest = new QuestionSaveRequest(null,
@@ -97,7 +98,7 @@ public class RecruitmentApiTest extends ApiTest {
     @DisplayName("유효하지 않은 마감일로 모집 공고를 저장한다.")
     void saveRecruitmentWithInvalidDeadline() {
         // given
-        LoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
+        AdminLoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
         String accessToken = adminTokenResponse.accessToken();
 
         String date = LocalDate.now().plusDays(10).toString();
@@ -124,7 +125,7 @@ public class RecruitmentApiTest extends ApiTest {
     @DisplayName("모집을 시작한다.")
     void startRecruiting() {
         // given
-        LoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
+        AdminLoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
         String accessToken = adminTokenResponse.accessToken();
         createRecruitment(accessToken);
 
@@ -145,7 +146,7 @@ public class RecruitmentApiTest extends ApiTest {
     @DisplayName("작성 중 단계가 아닌 모집 공고(이미 시작된)는 시작할 수 없다.")
     void startInvalidStateRecruitment() {
         // given
-        LoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
+        AdminLoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
         String accessToken = adminTokenResponse.accessToken();
         createRecruitment(accessToken);
 
@@ -173,12 +174,12 @@ public class RecruitmentApiTest extends ApiTest {
     @DisplayName("모집 중 지원 상태(지원자 수, 마감일)를 조회한다.")
     void getRecruitmentStateInProgress() {
         // given
-        LoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
+        AdminLoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
         String adminAccessToken = adminTokenResponse.accessToken();
         RecruitmentDetailsResponse recruitmentDetailsResponse = createRecruitment(adminAccessToken);
-        LoginResponse applicantATokenResponse = signUpApplicant(recruitmentDetailsResponse.code(),
+        ApplicantLoginResponse applicantATokenResponse = signUpApplicant(recruitmentDetailsResponse.code(),
                 "A" + TEST_EMAIL, TEST_PASSWORD);
-        LoginResponse applicantBTokenResponse = signUpApplicant(recruitmentDetailsResponse.code(),
+        ApplicantLoginResponse applicantBTokenResponse = signUpApplicant(recruitmentDetailsResponse.code(),
                 "B" + TEST_EMAIL, TEST_PASSWORD);
 
         ApplicationSaveRequest applicationSaveRequest = applicationSaveRequest();
@@ -208,7 +209,7 @@ public class RecruitmentApiTest extends ApiTest {
     @DisplayName("모집 공고 및 지원서 양식 상세 정보를 조회한다.")
     void getRecruitmentDetails() {
         // given
-        LoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
+        AdminLoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
         String adminAccessToken = adminTokenResponse.accessToken();
         RecruitmentDetailsResponse savedRecruitmentDetailsResponse = createRecruitment(adminAccessToken);
 
@@ -240,7 +241,7 @@ public class RecruitmentApiTest extends ApiTest {
     @DisplayName("모집 공고 및 지원서 양식 상세 정보를 모집 공고 코드로 조회한다.")
     void getRecruitmentDetailsByCode() {
         // given
-        LoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
+        AdminLoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
         String adminAccessToken = adminTokenResponse.accessToken();
         RecruitmentDetailsResponse savedRecruitmentDetailsResponse = createRecruitment(adminAccessToken);
 
@@ -262,7 +263,7 @@ public class RecruitmentApiTest extends ApiTest {
     @DisplayName("모집 마감기한을 변경한다.")
     void updateDeadline() {
         // given
-        LoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
+        AdminLoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
         String adminAccessToken = adminTokenResponse.accessToken();
         createRecruitment(adminAccessToken);
 
@@ -287,12 +288,12 @@ public class RecruitmentApiTest extends ApiTest {
     @DisplayName("모든 지원자에게 지원 결과 메일을 전송한다.")
     void sendOutcomeEmail() {
         // given
-        LoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
+        AdminLoginResponse adminTokenResponse = signUpAdmin(TEST_CLUB_NAME, TEST_PASSWORD);
         String adminAccessToken = adminTokenResponse.accessToken();
         RecruitmentDetailsResponse recruitmentDetailsResponse = createRecruitment(adminAccessToken);
-        LoginResponse applicantATokenResponse = signUpApplicant(recruitmentDetailsResponse.code(),
+        ApplicantLoginResponse applicantATokenResponse = signUpApplicant(recruitmentDetailsResponse.code(),
                 "A" + TEST_EMAIL, TEST_PASSWORD);
-        LoginResponse applicantBTokenResponse = signUpApplicant(recruitmentDetailsResponse.code(),
+        ApplicantLoginResponse applicantBTokenResponse = signUpApplicant(recruitmentDetailsResponse.code(),
                 "B" + TEST_EMAIL, TEST_PASSWORD);
 
         ApplicationSaveRequest applicationSaveRequest = applicationSaveRequest();

--- a/src/test/java/com/server/crews/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/server/crews/auth/application/AuthServiceTest.java
@@ -6,7 +6,8 @@ import com.server.crews.auth.domain.Role;
 import com.server.crews.auth.dto.LoginUser;
 import com.server.crews.auth.dto.request.AdminLoginRequest;
 import com.server.crews.auth.dto.request.ApplicantLoginRequest;
-import com.server.crews.auth.dto.response.LoginResponse;
+import com.server.crews.auth.dto.response.AdminLoginResponse;
+import com.server.crews.auth.dto.response.ApplicantLoginResponse;
 import com.server.crews.auth.repository.AdministratorRepository;
 import com.server.crews.auth.repository.ApplicantRepository;
 import com.server.crews.environ.service.ServiceTest;
@@ -42,13 +43,13 @@ class AuthServiceTest extends ServiceTest {
         AdminLoginRequest request = new AdminLoginRequest(clubName, password);
 
         // when
-        LoginResponse loginResponse = authService.loginForAdmin(request);
+        AdminLoginResponse adminLoginResponse = authService.loginForAdmin(request);
 
         // then
-        Optional<Administrator> createdAdmin = administratorRepository.findById(loginResponse.userId());
+        Optional<Administrator> createdAdmin = administratorRepository.findById(adminLoginResponse.adminId());
         assertSoftly(softAssertions -> {
             softAssertions.assertThat(createdAdmin).isNotEmpty();
-            softAssertions.assertThat(loginResponse.accessToken()).isNotNull();
+            softAssertions.assertThat(adminLoginResponse.accessToken()).isNotNull();
         });
     }
 
@@ -60,13 +61,13 @@ class AuthServiceTest extends ServiceTest {
         AdminLoginRequest request = new AdminLoginRequest(administrator.getClubName(), administrator.getPassword());
 
         // when
-        LoginResponse loginResponse = authService.loginForAdmin(request);
+        AdminLoginResponse adminLoginResponse = authService.loginForAdmin(request);
 
         // then
-        Optional<Administrator> createdAdmin = administratorRepository.findById(loginResponse.userId());
+        Optional<Administrator> createdAdmin = administratorRepository.findById(adminLoginResponse.adminId());
         assertSoftly(softAssertions -> {
             softAssertions.assertThat(createdAdmin).isNotEmpty();
-            softAssertions.assertThat(loginResponse.accessToken()).isNotNull();
+            softAssertions.assertThat(adminLoginResponse.accessToken()).isNotNull();
         });
     }
 
@@ -81,13 +82,13 @@ class AuthServiceTest extends ServiceTest {
         ApplicantLoginRequest request = new ApplicantLoginRequest(recruitment.getCode(), email, password);
 
         // when
-        LoginResponse loginResponse = authService.loginForApplicant(request);
+        ApplicantLoginResponse applicantLoginResponse = authService.loginForApplicant(request);
 
         // then
-        Optional<Applicant> createdApplicant = applicantRepository.findById(loginResponse.userId());
+        Optional<Applicant> createdApplicant = applicantRepository.findById(applicantLoginResponse.applicantId());
         assertSoftly(softAssertions -> {
             softAssertions.assertThat(createdApplicant).isNotEmpty();
-            softAssertions.assertThat(loginResponse.accessToken()).isNotNull();
+            softAssertions.assertThat(applicantLoginResponse.accessToken()).isNotNull();
         });
     }
 
@@ -101,13 +102,13 @@ class AuthServiceTest extends ServiceTest {
         ApplicantLoginRequest request = new ApplicantLoginRequest(recruitment.getCode(), applicant.getEmail(), applicant.getPassword());
 
         // when
-        LoginResponse loginResponse = authService.loginForApplicant(request);
+        ApplicantLoginResponse applicantLoginResponse = authService.loginForApplicant(request);
 
         // then
-        Optional<Applicant> createdApplicant = applicantRepository.findById(loginResponse.userId());
+        Optional<Applicant> createdApplicant = applicantRepository.findById(applicantLoginResponse.applicantId());
         assertSoftly(softAssertions -> {
             softAssertions.assertThat(createdApplicant).isNotEmpty();
-            softAssertions.assertThat(loginResponse.accessToken()).isNotNull();
+            softAssertions.assertThat(applicantLoginResponse.accessToken()).isNotNull();
         });
     }
 

--- a/src/test/java/com/server/crews/environ/service/ServiceTest.java
+++ b/src/test/java/com/server/crews/environ/service/ServiceTest.java
@@ -1,5 +1,9 @@
 package com.server.crews.environ.service;
 
+import static com.server.crews.fixture.RecruitmentFixture.DEFAULT_CODE;
+import static com.server.crews.fixture.RecruitmentFixture.DEFAULT_DEADLINE;
+import static com.server.crews.fixture.UserFixture.TEST_PASSWORD;
+
 import com.server.crews.auth.domain.Administrator;
 import com.server.crews.auth.domain.Applicant;
 import com.server.crews.environ.DatabaseCleaner;
@@ -12,10 +16,10 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-import static com.server.crews.fixture.RecruitmentFixture.DEFAULT_CODE;
-import static com.server.crews.fixture.UserFixture.TEST_PASSWORD;
-
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.NONE,
+        properties = {"schedules.cron.closing-recruitment="}
+)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public abstract class ServiceTest {
     @Autowired
@@ -36,38 +40,26 @@ public abstract class ServiceTest {
     }
 
     protected TestRecruitment LIKE_LION_RECRUITMENT(Administrator publisher) {
-        TestRecruitment testRecruitment = new TestRecruitment(serviceTestEnviron);
-        testRecruitment.create(DEFAULT_CODE, "LIKE LION", publisher);
-        return testRecruitment;
+        return new TestRecruitment(serviceTestEnviron).create(DEFAULT_CODE, "LIKE LION", DEFAULT_DEADLINE, publisher);
     }
 
     protected TestAdmin LIKE_LION_ADMIN() {
-        TestAdmin testAdmin = new TestAdmin(serviceTestEnviron);
-        testAdmin.create("LIKE_LION", TEST_PASSWORD);
-        return testAdmin;
+        return new TestAdmin(serviceTestEnviron).create("LIKE_LION", TEST_PASSWORD);
     }
 
     protected TestApplicant JONGMEE_APPLICANT(Recruitment recruitment) {
-        TestApplicant testApplicant = new TestApplicant(serviceTestEnviron);
-        testApplicant.create("JONGMEE@gmail.com", TEST_PASSWORD, recruitment);
-        return testApplicant;
+        return new TestApplicant(serviceTestEnviron).create("JONGMEE@gmail.com", TEST_PASSWORD, recruitment);
     }
 
     protected TestApplicant KYUNGHO_APPLICANT(Recruitment recruitment) {
-        TestApplicant testApplicant = new TestApplicant(serviceTestEnviron);
-        testApplicant.create("KYUNGHO@gmail.com", TEST_PASSWORD, recruitment);
-        return testApplicant;
+        return new TestApplicant(serviceTestEnviron).create("KYUNGHO@gmail.com", TEST_PASSWORD, recruitment);
     }
 
     protected TestApplication JONGMEE_APPLICATION(Applicant applicant) {
-        TestApplication testApplication = new TestApplication(serviceTestEnviron);
-        testApplication.create(applicant, "20202020", "생명과학", "종미");
-        return testApplication;
+        return new TestApplication(serviceTestEnviron).create(applicant, "20202020", "생명과학", "종미");
     }
 
     protected TestApplication KYUNGHO_APPLICATION(Applicant applicant) {
-        TestApplication testApplication = new TestApplication(serviceTestEnviron);
-        testApplication.create(applicant, "20202021", "컴퓨터공학", "경호");
-        return testApplication;
+        return new TestApplication(serviceTestEnviron).create(applicant, "20202021", "컴퓨터공학", "경호");
     }
 }

--- a/src/test/java/com/server/crews/environ/service/ServiceTest.java
+++ b/src/test/java/com/server/crews/environ/service/ServiceTest.java
@@ -18,7 +18,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SpringBootTest(
         webEnvironment = SpringBootTest.WebEnvironment.NONE,
-        properties = {"schedules.cron.closing-recruitment="}
+        properties = {"schedules.cron.closing-recruitment=0 0 0 31 2 ?"}
 )
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public abstract class ServiceTest {

--- a/src/test/java/com/server/crews/environ/service/TestRecruitment.java
+++ b/src/test/java/com/server/crews/environ/service/TestRecruitment.java
@@ -7,10 +7,10 @@ import com.server.crews.recruitment.domain.Recruitment;
 import com.server.crews.recruitment.domain.Section;
 import com.server.crews.recruitment.domain.SelectiveQuestion;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.server.crews.fixture.RecruitmentFixture.DEFAULT_DEADLINE;
 import static com.server.crews.fixture.RecruitmentFixture.DEFAULT_DESCRIPTION;
 
 public class TestRecruitment {
@@ -29,9 +29,9 @@ public class TestRecruitment {
         this.choices = new ArrayList<>();
     }
 
-    public TestRecruitment create(String code, String clubName, Administrator publisher) {
+    public TestRecruitment create(String code, String clubName, LocalDateTime deadline, Administrator publisher) {
         Recruitment recruitment = new Recruitment(null, code, clubName + " 99기 모집", DEFAULT_DESCRIPTION,
-                DEFAULT_DEADLINE, publisher, List.of());
+                deadline, publisher, List.of());
         this.recruitment = environ.recruitmentRepository().save(recruitment);
         return this;
     }

--- a/src/test/java/com/server/crews/environ/service/TestRecruitment.java
+++ b/src/test/java/com/server/crews/environ/service/TestRecruitment.java
@@ -10,7 +10,7 @@ import com.server.crews.recruitment.domain.SelectiveQuestion;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.server.crews.fixture.RecruitmentFixture.DEFAULT_CLOSING_DATE;
+import static com.server.crews.fixture.RecruitmentFixture.DEFAULT_DEADLINE;
 import static com.server.crews.fixture.RecruitmentFixture.DEFAULT_DESCRIPTION;
 
 public class TestRecruitment {
@@ -31,7 +31,7 @@ public class TestRecruitment {
 
     public TestRecruitment create(String code, String clubName, Administrator publisher) {
         Recruitment recruitment = new Recruitment(null, code, clubName + " 99기 모집", DEFAULT_DESCRIPTION,
-                DEFAULT_CLOSING_DATE, publisher, List.of());
+                DEFAULT_DEADLINE, publisher, List.of());
         this.recruitment = environ.recruitmentRepository().save(recruitment);
         return this;
     }

--- a/src/test/java/com/server/crews/fixture/RecruitmentFixture.java
+++ b/src/test/java/com/server/crews/fixture/RecruitmentFixture.java
@@ -17,7 +17,7 @@ import static com.server.crews.fixture.SectionFixture.BACKEND_SECTION_NAME;
 import static com.server.crews.fixture.SectionFixture.FRONTEND_SECTION_NAME;
 
 public class RecruitmentFixture {
-    public static final LocalDateTime DEFAULT_CLOSING_DATE = LocalDateTime.now().plusMonths(1L);
+    public static final LocalDateTime DEFAULT_DEADLINE = LocalDateTime.of(2030, 9, 5, 18, 0);
     public static final String DEFAULT_CODE = "SECRET_CODE";
     public static final String DEFAULT_TITLE = "TITLE";
     public static final String DEFAULT_DESCRIPTION = "DESCRIPTION";
@@ -28,9 +28,9 @@ public class RecruitmentFixture {
     public static final SectionSaveRequest BACKEND_SECTION_REQUEST = new SectionSaveRequest(null, BACKEND_SECTION_NAME, DEFAULT_DESCRIPTION, QUESTION_REQUESTS);
     public static final SectionSaveRequest FRONTEND_SECTION_REQUEST = new SectionSaveRequest(null, FRONTEND_SECTION_NAME, DEFAULT_DESCRIPTION, QUESTION_REQUESTS);
     public static final List<SectionSaveRequest> SECTION_REQUESTS = List.of(BACKEND_SECTION_REQUEST, FRONTEND_SECTION_REQUEST);
-    public static final RecruitmentSaveRequest RECRUITMENT_SAVE_REQUEST = new RecruitmentSaveRequest(null, DEFAULT_TITLE, DEFAULT_DESCRIPTION, SECTION_REQUESTS, DEFAULT_CLOSING_DATE.toString());
+    public static final RecruitmentSaveRequest RECRUITMENT_SAVE_REQUEST = new RecruitmentSaveRequest(null, DEFAULT_TITLE, DEFAULT_DESCRIPTION, SECTION_REQUESTS, DEFAULT_DEADLINE.toString());
 
     public static Recruitment TEST_RECRUITMENT(Administrator publisher) {
-        return new Recruitment(null, DEFAULT_CODE, DEFAULT_TITLE, DEFAULT_DESCRIPTION, DEFAULT_CLOSING_DATE, publisher, List.of());
+        return new Recruitment(null, DEFAULT_CODE, DEFAULT_TITLE, DEFAULT_DESCRIPTION, DEFAULT_DEADLINE, publisher, List.of());
     }
 }

--- a/src/test/java/com/server/crews/fixture/TokenFixture.java
+++ b/src/test/java/com/server/crews/fixture/TokenFixture.java
@@ -2,7 +2,7 @@ package com.server.crews.fixture;
 
 import com.server.crews.auth.dto.request.NewApplicantRequest;
 import com.server.crews.auth.dto.request.NewRecruitmentRequest;
-import com.server.crews.auth.dto.response.LoginResponse;
+import com.server.crews.auth.dto.response.AdminLoginResponse;
 import io.restassured.RestAssured;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -11,7 +11,7 @@ import static com.server.crews.fixture.RecruitmentFixture.DEFAULT_CODE;
 
 public class TokenFixture {
 
-    public static LoginResponse RECRUITMENT_ID_AND_ACCESS_TOKEN() {
+    public static AdminLoginResponse RECRUITMENT_ID_AND_ACCESS_TOKEN() {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(new NewRecruitmentRequest(DEFAULT_CODE))
@@ -19,18 +19,18 @@ public class TokenFixture {
                 .then().log().all()
                 .statusCode(HttpStatus.CREATED.value())
                 .extract()
-                .as(LoginResponse.class);
+                .as(AdminLoginResponse.class);
     }
 
     public static String APPLICANT_ID_AND_ACCESS_TOKEN(final Long recruitmentId) {
-        LoginResponse loginResponse = RestAssured.given().log().all()
+        AdminLoginResponse adminLoginResponse = RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(new NewApplicantRequest(DEFAULT_CODE, recruitmentId))
                 .when().post("/auth/applicant/secret-code")
                 .then().log().all()
                 .statusCode(HttpStatus.CREATED.value())
                 .extract()
-                .as(LoginResponse.class);
-        return loginResponse.accessToken();
+                .as(AdminLoginResponse.class);
+        return adminLoginResponse.accessToken();
     }
 }

--- a/src/test/java/com/server/crews/recruitment/application/ClosingRecruitmentTest.java
+++ b/src/test/java/com/server/crews/recruitment/application/ClosingRecruitmentTest.java
@@ -3,15 +3,20 @@ package com.server.crews.recruitment.application;
 import static com.server.crews.fixture.RecruitmentFixture.DEFAULT_CODE;
 import static com.server.crews.fixture.RecruitmentFixture.DEFAULT_DEADLINE;
 import static com.server.crews.fixture.UserFixture.TEST_PASSWORD;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.server.crews.auth.domain.Administrator;
 import com.server.crews.environ.service.ServiceTestEnviron;
 import com.server.crews.environ.service.TestAdmin;
 import com.server.crews.environ.service.TestRecruitment;
+import com.server.crews.recruitment.domain.Progress;
+import com.server.crews.recruitment.domain.Recruitment;
+import com.server.crews.recruitment.repository.RecruitmentRepository;
+import java.time.Clock;
+import java.time.Instant;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -23,24 +28,31 @@ import org.springframework.boot.test.mock.mockito.SpyBean;
 )
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class ClosingRecruitmentTest {
-    @SpyBean
-    private RecruitmentService recruitmentService;
-
     @Autowired
     private ServiceTestEnviron serviceTestEnviron;
+
+    @Autowired
+    private RecruitmentRepository recruitmentRepository;
+
+    @SpyBean
+    private Clock clock;
 
     @Test
     @DisplayName("일정한 시간 간격으로 모집 마감 기한에 도달한 모집 공고들을 마감한다.")
     void closeRecruitments() throws InterruptedException {
         // given
+        BDDMockito.given(clock.instant())
+                .willReturn(Instant.parse("2031-09-05T00:00:00Z"));
         Administrator publisher = new TestAdmin(serviceTestEnviron).create("LIKE_LION", TEST_PASSWORD)
                 .administrator();
-        new TestRecruitment(serviceTestEnviron).create(DEFAULT_CODE, "LIKE LION", DEFAULT_DEADLINE, publisher);
+        Recruitment recruitment = new TestRecruitment(serviceTestEnviron)
+                .create(DEFAULT_CODE, "LIKE LION", DEFAULT_DEADLINE, publisher).recruitment();
 
         // when
         Thread.sleep(2000);
 
         // then
-        verify(recruitmentService, times(1)).closeRecruitments();
+        Recruitment updatedRecruitment = recruitmentRepository.findById(recruitment.getId()).get();
+        assertThat(updatedRecruitment.getProgress()).isEqualTo(Progress.COMPLETION);
     }
 }

--- a/src/test/java/com/server/crews/recruitment/application/ClosingRecruitmentTest.java
+++ b/src/test/java/com/server/crews/recruitment/application/ClosingRecruitmentTest.java
@@ -9,7 +9,7 @@ import com.server.crews.auth.domain.Administrator;
 import com.server.crews.environ.service.ServiceTestEnviron;
 import com.server.crews.environ.service.TestAdmin;
 import com.server.crews.environ.service.TestRecruitment;
-import com.server.crews.recruitment.domain.Progress;
+import com.server.crews.recruitment.domain.RecruitmentProgress;
 import com.server.crews.recruitment.domain.Recruitment;
 import com.server.crews.recruitment.repository.RecruitmentRepository;
 import java.time.Clock;
@@ -53,6 +53,6 @@ public class ClosingRecruitmentTest {
 
         // then
         Recruitment updatedRecruitment = recruitmentRepository.findById(recruitment.getId()).get();
-        assertThat(updatedRecruitment.getProgress()).isEqualTo(Progress.COMPLETION);
+        assertThat(updatedRecruitment.getRecruitmentProgress()).isEqualTo(RecruitmentProgress.COMPLETION);
     }
 }

--- a/src/test/java/com/server/crews/recruitment/application/ClosingRecruitmentTest.java
+++ b/src/test/java/com/server/crews/recruitment/application/ClosingRecruitmentTest.java
@@ -1,0 +1,46 @@
+package com.server.crews.recruitment.application;
+
+import static com.server.crews.fixture.RecruitmentFixture.DEFAULT_CODE;
+import static com.server.crews.fixture.RecruitmentFixture.DEFAULT_DEADLINE;
+import static com.server.crews.fixture.UserFixture.TEST_PASSWORD;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.server.crews.auth.domain.Administrator;
+import com.server.crews.environ.service.ServiceTestEnviron;
+import com.server.crews.environ.service.TestAdmin;
+import com.server.crews.environ.service.TestRecruitment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.NONE,
+        properties = "schedules.cron.closing-recruitment=0/2 * * * * ?"
+)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class ClosingRecruitmentTest {
+    @SpyBean
+    private RecruitmentService recruitmentService;
+
+    @Autowired
+    private ServiceTestEnviron serviceTestEnviron;
+
+    @Test
+    @DisplayName("일정한 시간 간격으로 모집 마감 기한에 도달한 모집 공고들을 마감한다.")
+    void closeRecruitments() throws InterruptedException {
+        // given
+        Administrator publisher = new TestAdmin(serviceTestEnviron).create("LIKE_LION", TEST_PASSWORD)
+                .administrator();
+        new TestRecruitment(serviceTestEnviron).create(DEFAULT_CODE, "LIKE LION", DEFAULT_DEADLINE, publisher);
+
+        // when
+        Thread.sleep(2000);
+
+        // then
+        verify(recruitmentService, times(1)).closeRecruitments();
+    }
+}

--- a/src/test/java/com/server/crews/recruitment/application/RecruitmentServiceTest.java
+++ b/src/test/java/com/server/crews/recruitment/application/RecruitmentServiceTest.java
@@ -3,7 +3,7 @@ package com.server.crews.recruitment.application;
 import static com.server.crews.fixture.QuestionFixture.NARRATIVE_QUESTION;
 import static com.server.crews.fixture.QuestionFixture.SELECTIVE_QUESTION;
 import static com.server.crews.fixture.QuestionFixture.STRENGTH_QUESTION;
-import static com.server.crews.fixture.RecruitmentFixture.DEFAULT_CLOSING_DATE;
+import static com.server.crews.fixture.RecruitmentFixture.DEFAULT_DEADLINE;
 import static com.server.crews.fixture.RecruitmentFixture.DEFAULT_DESCRIPTION;
 import static com.server.crews.fixture.RecruitmentFixture.DEFAULT_TITLE;
 import static com.server.crews.fixture.RecruitmentFixture.RECRUITMENT_SAVE_REQUEST;
@@ -77,7 +77,7 @@ class RecruitmentServiceTest extends ServiceTest {
                 DEFAULT_DESCRIPTION,
                 List.of(selectiveQuestionCreateRequest));
         RecruitmentSaveRequest recruitmentCreateRequest = new RecruitmentSaveRequest(null, DEFAULT_TITLE,
-                DEFAULT_DESCRIPTION, List.of(sectionsCreateRequest), DEFAULT_CLOSING_DATE.toString());
+                DEFAULT_DESCRIPTION, List.of(sectionsCreateRequest), DEFAULT_DEADLINE.toString());
 
         RecruitmentDetailsResponse savedRecruitmentResponse = recruitmentService.saveRecruitment(publisher.getId(),
                 recruitmentCreateRequest);
@@ -93,7 +93,7 @@ class RecruitmentServiceTest extends ServiceTest {
         SectionSaveRequest sectionSaveRequest = new SectionSaveRequest(sectionId, "변경된 섹션 이름", DEFAULT_DESCRIPTION,
                 List.of(selectiveQuestionSaveRequest));
         RecruitmentSaveRequest recruitmentSaveRequest = new RecruitmentSaveRequest(recruitmentId, "변경된 모집 공고 제목",
-                DEFAULT_DESCRIPTION, List.of(sectionSaveRequest), DEFAULT_CLOSING_DATE.toString());
+                DEFAULT_DESCRIPTION, List.of(sectionSaveRequest), DEFAULT_DEADLINE.toString());
 
         // when
         RecruitmentDetailsResponse response = recruitmentService.saveRecruitment(publisher.getId(),

--- a/src/test/java/com/server/crews/recruitment/application/RecruitmentServiceTest.java
+++ b/src/test/java/com/server/crews/recruitment/application/RecruitmentServiceTest.java
@@ -20,7 +20,7 @@ import com.server.crews.environ.service.ServiceTest;
 import com.server.crews.environ.service.TestRecruitment;
 import com.server.crews.global.exception.CrewsException;
 import com.server.crews.global.exception.ErrorCode;
-import com.server.crews.recruitment.domain.Progress;
+import com.server.crews.recruitment.domain.RecruitmentProgress;
 import com.server.crews.recruitment.domain.Recruitment;
 import com.server.crews.recruitment.dto.request.ChoiceSaveRequest;
 import com.server.crews.recruitment.dto.request.QuestionSaveRequest;
@@ -130,7 +130,7 @@ class RecruitmentServiceTest extends ServiceTest {
 
         // then
         Recruitment updatedRecruitment = recruitmentRepository.findById(recruitment.getId()).get();
-        assertThat(updatedRecruitment.getProgress()).isEqualTo(Progress.IN_PROGRESS);
+        assertThat(updatedRecruitment.getRecruitmentProgress()).isEqualTo(RecruitmentProgress.IN_PROGRESS);
     }
 
     @Test
@@ -181,7 +181,7 @@ class RecruitmentServiceTest extends ServiceTest {
         // then
         Recruitment updatedRecruitment = recruitmentRepository.findById(recruitment.getId()).get();
         assertAll(
-                () -> assertThat(updatedRecruitment.getProgress()).isEqualTo(Progress.ANNOUNCED),
+                () -> assertThat(updatedRecruitment.getRecruitmentProgress()).isEqualTo(RecruitmentProgress.ANNOUNCED),
                 () -> assertThat(events.stream(OutcomeDeterminedEvent.class).count()).isSameAs(1L)
         );
     }

--- a/src/test/java/com/server/crews/recruitment/application/RecruitmentServiceTest.java
+++ b/src/test/java/com/server/crews/recruitment/application/RecruitmentServiceTest.java
@@ -48,7 +48,7 @@ class RecruitmentServiceTest extends ServiceTest {
     private RecruitmentRepository recruitmentRepository;
 
     @Autowired
-    ApplicationEvents events;
+    private ApplicationEvents events;
 
     @Test
     @DisplayName("지원서 양식을 최초로 저장한다.")

--- a/src/test/java/com/server/crews/recruitment/domain/RecruitmentTest.java
+++ b/src/test/java/com/server/crews/recruitment/domain/RecruitmentTest.java
@@ -17,14 +17,14 @@ class RecruitmentTest {
 
     @Test
     @DisplayName("모집 마감일은 지금 이전이 될 수 없다.")
-    void validateClosingDate() {
+    void validateDeadline() {
         // given
-        LocalDateTime invalidClosingDate = LocalDateTime.now().minusDays(1L);
+        LocalDateTime invalidDeadline = LocalDateTime.now().minusDays(1L);
 
         // when & then
-        assertThatThrownBy(() -> new Recruitment(null, DEFAULT_CODE, DEFAULT_TITLE, DEFAULT_DESCRIPTION, invalidClosingDate,
+        assertThatThrownBy(() -> new Recruitment(null, DEFAULT_CODE, DEFAULT_TITLE, DEFAULT_DESCRIPTION, invalidDeadline,
                 TEST_ADMIN(), List.of()))
                 .isInstanceOf(CrewsException.class)
-                .hasMessage(ErrorCode.INVALID_CLOSING_DATE.getMessage());
+                .hasMessage(ErrorCode.INVALID_DEADLINE.getMessage());
     }
 }

--- a/src/test/java/com/server/crews/recruitment/domain/RecruitmentTest.java
+++ b/src/test/java/com/server/crews/recruitment/domain/RecruitmentTest.java
@@ -8,7 +8,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.server.crews.global.exception.CrewsException;
 import com.server.crews.global.exception.ErrorCode;
+import java.time.Clock;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,11 +23,13 @@ class RecruitmentTest {
     @DisplayName("모집 마감일은 지금 이전이 될 수 없다.")
     void validateDeadline() {
         // given
-        LocalDateTime invalidDeadline = LocalDateTime.now().minusDays(1L);
+        LocalTime time = LocalTime.of(0, 0);
+        LocalDate date = LocalDate.now(Clock.system(ZoneId.of("Asia/Seoul"))).minusDays(1);
+        LocalDateTime invalidDeadline = LocalDateTime.of(date, time);
 
         // when & then
-        assertThatThrownBy(() -> new Recruitment(null, DEFAULT_CODE, DEFAULT_TITLE, DEFAULT_DESCRIPTION, invalidDeadline,
-                TEST_ADMIN(), List.of()))
+        assertThatThrownBy(() -> new Recruitment(null, DEFAULT_CODE, DEFAULT_TITLE, DEFAULT_DESCRIPTION,
+                invalidDeadline, TEST_ADMIN(), List.of()))
                 .isInstanceOf(CrewsException.class)
                 .hasMessage(ErrorCode.INVALID_DEADLINE.getMessage());
     }

--- a/src/test/java/com/server/crews/recruitment/presentation/RecruitmentControllerTest.java
+++ b/src/test/java/com/server/crews/recruitment/presentation/RecruitmentControllerTest.java
@@ -79,12 +79,12 @@ class RecruitmentControllerTest extends ControllerTest {
 
     @Test
     @DisplayName("모집 공고의 마감일이 null인지 검증한다.")
-    void validRecruitmentClosingDate() throws Exception {
+    void validRecruitmentDeadline() throws Exception {
         // given
         String invalidRecruitmentSaveRequest = """
                         {
                             "title": "모집공고 제목입니다.",
-                            "closingDate": ""
+                            "deadline": ""
                         }
                 """;
 
@@ -99,12 +99,12 @@ class RecruitmentControllerTest extends ControllerTest {
 
     @Test
     @DisplayName("모집 공고의 마감일 형식을 검증한다.")
-    void validateRecruitmentClosingDateForm() throws Exception {
+    void validateRecruitmentDeadlineForm() throws Exception {
         // given
         String invalidRecruitmentSaveRequest = """
                         {
                             "title": "모집공고 제목입니다.",
-                            "closingDate": "invalid"
+                            "deadline": "invalid"
                         }
                 """;
 
@@ -175,7 +175,7 @@ class RecruitmentControllerTest extends ControllerTest {
         String invalidRecruitmentSaveRequest = """
                         {
                             "title": "모집 공고 제목",
-                            "closingDate": "2030-09-12T00:00:00",
+                            "deadline": "2030-09-12T00:00:00",
                             "sections": [
                                 {
                                     "name": "파트1",


### PR DESCRIPTION
## Description 📒

>정각 단위로 모집 공고 마감 기한을 설정할 수 있다. 스프링 스케줄러로 1시간에 한 번씩 마감된 모집 공고 목록을 확인하여 `RecruitmentProgress` 값을 `COMPLETION`으로 업데이트한다.

## Issue 💬

#24
