### PR TITLE
쿼리 실행 계획 확인 및 인덱스 추가

### DIFF
--- a/src/main/java/com/server/crews/applicant/domain/Application.java
+++ b/src/main/java/com/server/crews/applicant/domain/Application.java
@@ -1,7 +1,6 @@
 package com.server.crews.applicant.domain;
 
 import com.server.crews.auth.domain.Applicant;
-import com.server.crews.auth.domain.Role;
 import com.server.crews.recruitment.domain.Recruitment;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -12,6 +11,7 @@ import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
@@ -24,7 +24,12 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "application")
+@Table(name = "application",
+        indexes = {
+                @Index(columnList = "recruitment_id", name = "idx_recruitment_id"),
+                @Index(columnList = "applicant_id", name = "idx_applicant_id")
+        }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Application {
 

--- a/src/main/java/com/server/crews/applicant/domain/NarrativeAnswer.java
+++ b/src/main/java/com/server/crews/applicant/domain/NarrativeAnswer.java
@@ -7,14 +7,19 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
+@Table(name = "narrative_answer",
+        indexes = @Index(columnList = "application_id", name = "idx_application_id")
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NarrativeAnswer {
     @Id

--- a/src/main/java/com/server/crews/applicant/domain/SelectiveAnswer.java
+++ b/src/main/java/com/server/crews/applicant/domain/SelectiveAnswer.java
@@ -7,6 +7,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -16,7 +17,9 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "selective_answer")
+@Table(name = "selective_answer",
+        indexes = @Index(columnList = "application_id", name = "idx_application_id")
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SelectiveAnswer {
     @Id

--- a/src/main/java/com/server/crews/applicant/repository/ApplicationRepository.java
+++ b/src/main/java/com/server/crews/applicant/repository/ApplicationRepository.java
@@ -25,12 +25,6 @@ public interface ApplicationRepository extends JpaRepository<Application, Long>,
 
     @Query("""
             select a from Application a
-            where a.applicant.id = :applicantId
-            """)
-    Optional<Application> findByApplicantId(@Param("applicantId") Long applicantId);
-
-    @Query("""
-            select a from Application a
             join fetch a.recruitment r
             join fetch r.publisher
             where a.id = :id

--- a/src/main/java/com/server/crews/applicant/repository/ApplicationRepository.java
+++ b/src/main/java/com/server/crews/applicant/repository/ApplicationRepository.java
@@ -2,6 +2,7 @@ package com.server.crews.applicant.repository;
 
 import com.server.crews.applicant.domain.Application;
 import com.server.crews.recruitment.domain.Recruitment;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -14,6 +15,13 @@ public interface ApplicationRepository extends JpaRepository<Application, Long>,
             where recruitment = :recruitment
             """)
     int countAllByRecruitment(@Param("recruitment") Recruitment recruitment);
+
+    @Query("""
+            select application from Application application
+            join fetch application.applicant
+            where application.recruitment = :recruitment
+            """)
+    List<Application> findAllByRecruitmentWithApplicant(@Param("recruitment") Recruitment recruitment);
 
     @Query("""
             select a from Application a

--- a/src/main/java/com/server/crews/auth/application/AuthService.java
+++ b/src/main/java/com/server/crews/auth/application/AuthService.java
@@ -1,7 +1,5 @@
 package com.server.crews.auth.application;
 
-import com.server.crews.applicant.domain.Application;
-import com.server.crews.applicant.repository.ApplicationRepository;
 import com.server.crews.auth.domain.Administrator;
 import com.server.crews.auth.domain.Applicant;
 import com.server.crews.auth.domain.Role;
@@ -23,7 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService {
     private final AdministratorRepository administratorRepository;
     private final ApplicantRepository applicantRepository;
-    private final ApplicationRepository applicationRepository;
     private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
@@ -49,11 +46,8 @@ public class AuthService {
 
         Applicant applicant = applicantRepository.findByEmail(email)
                 .orElseGet(() -> createApplicant(email, password));
-        Long applicationId = applicationRepository.findByApplicantId(applicant.getId())
-                .map(Application::getId)
-                .orElse(null);
         String accessToken = jwtTokenProvider.createAccessToken(Role.APPLICANT, email);
-        return new ApplicantLoginResponse(applicant.getId(), accessToken, applicationId);
+        return new ApplicantLoginResponse(applicant.getId(), accessToken);
     }
 
     private Applicant createApplicant(String email, String password) {

--- a/src/main/java/com/server/crews/auth/application/AuthService.java
+++ b/src/main/java/com/server/crews/auth/application/AuthService.java
@@ -14,7 +14,6 @@ import com.server.crews.auth.repository.AdministratorRepository;
 import com.server.crews.auth.repository.ApplicantRepository;
 import com.server.crews.global.exception.CrewsException;
 import com.server.crews.global.exception.ErrorCode;
-import com.server.crews.recruitment.repository.RecruitmentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,7 +23,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService {
     private final AdministratorRepository administratorRepository;
     private final ApplicantRepository applicantRepository;
-    private final RecruitmentRepository recruitmentRepository;
     private final ApplicationRepository applicationRepository;
     private final JwtTokenProvider jwtTokenProvider;
 

--- a/src/main/java/com/server/crews/auth/dto/response/ApplicantLoginResponse.java
+++ b/src/main/java/com/server/crews/auth/dto/response/ApplicantLoginResponse.java
@@ -1,4 +1,4 @@
 package com.server.crews.auth.dto.response;
 
-public record ApplicantLoginResponse(Long applicantId, String accessToken, Long applicationId) {
+public record ApplicantLoginResponse(Long applicantId, String accessToken) {
 }

--- a/src/main/java/com/server/crews/recruitment/application/RecruitmentService.java
+++ b/src/main/java/com/server/crews/recruitment/application/RecruitmentService.java
@@ -140,7 +140,7 @@ public class RecruitmentService {
         if (recruitment.isAnnounced()) {
             throw new CrewsException(ErrorCode.ALREADY_ANNOUNCED);
         }
-        List<Application> applications = applicationRepository.findAllWithApplicantByPublisherId(recruitment.getId());
+        List<Application> applications = applicationRepository.findAllByRecruitmentWithApplicant(recruitment);
         applications.stream().filter(Application::isNotDetermined)
                 .forEach(Application::reject);
 

--- a/src/main/java/com/server/crews/recruitment/domain/NarrativeQuestion.java
+++ b/src/main/java/com/server/crews/recruitment/domain/NarrativeQuestion.java
@@ -8,6 +8,7 @@ import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -19,7 +20,9 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @AllArgsConstructor
-@Table(name = "narrative_question")
+@Table(name = "narrative_question",
+        indexes = @Index(columnList = "section_id", name = "idx_section_id")
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NarrativeQuestion {
     @Id

--- a/src/main/java/com/server/crews/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/server/crews/recruitment/domain/Recruitment.java
@@ -15,6 +15,7 @@ import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
@@ -33,7 +34,12 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @Entity
-@Table(name = "recruitment")
+@Table(name = "recruitment",
+        indexes = {
+                @Index(columnList = "publisher_id", name = "idx_publisher_id"),
+                @Index(columnList = "code", name = "idx_code")
+        }
+)
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/com/server/crews/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/server/crews/recruitment/domain/Recruitment.java
@@ -8,6 +8,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
@@ -53,6 +55,7 @@ public class Recruitment {
     private String description;
 
     @Column(name = "progress", nullable = false)
+    @Enumerated(EnumType.STRING)
     private RecruitmentProgress progress;
 
     @Column(name = "deadline", nullable = false)

--- a/src/main/java/com/server/crews/recruitment/domain/SelectiveQuestion.java
+++ b/src/main/java/com/server/crews/recruitment/domain/SelectiveQuestion.java
@@ -9,6 +9,7 @@ import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
@@ -21,7 +22,9 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "selective_question")
+@Table(name = "selective_question",
+        indexes = @Index(columnList = "section_id", name = "idx_section_id")
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SelectiveQuestion {
     @Id


### PR DESCRIPTION
## Description 📒

>현재 사용되는 모든 쿼리의 실행 계획을 확인하고 인덱스를 추가한다. fk constraint를 사용하고 있지 않아 대부분 연관관계에 대한 인덱스를 추가했다.

## Issue 💬

#51
