### PR TITLE
배포 후 사소한 오류 및 리프레시 토큰 생성 로직 수정

### DIFF
--- a/src/main/java/com/server/crews/auth/application/AuthService.java
+++ b/src/main/java/com/server/crews/auth/application/AuthService.java
@@ -31,7 +31,7 @@ public class AuthService {
         Administrator administrator = administratorRepository.findByClubName(clubName)
                 .orElseGet(() -> createAdmin(clubName, password));
         String accessToken = jwtTokenProvider.createAccessToken(Role.ADMIN, clubName);
-        return new AdminLoginResponse(administrator.getId(), accessToken);
+        return new AdminLoginResponse(administrator.getClubName(), accessToken);
     }
 
     private Administrator createAdmin(String clubName, String password) {
@@ -47,7 +47,7 @@ public class AuthService {
         Applicant applicant = applicantRepository.findByEmail(email)
                 .orElseGet(() -> createApplicant(email, password));
         String accessToken = jwtTokenProvider.createAccessToken(Role.APPLICANT, email);
-        return new ApplicantLoginResponse(applicant.getId(), accessToken);
+        return new ApplicantLoginResponse(applicant.getEmail(), accessToken);
     }
 
     private Applicant createApplicant(String email, String password) {

--- a/src/main/java/com/server/crews/auth/domain/RefreshToken.java
+++ b/src/main/java/com/server/crews/auth/domain/RefreshToken.java
@@ -2,29 +2,30 @@ package com.server.crews.auth.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
+@Table(name = "refresh_token")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RefreshToken {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @Column(name = "username")
+    private String username;
 
-    @Column(nullable = false)
+    @Column(nullable = false, name = "token")
     private String token;
 
-    @Column(nullable = false)
-    private Long ownerId;
-
-    public RefreshToken(final String token, final Long ownerId) {
+    public RefreshToken(String username, String token) {
+        this.username = username;
         this.token = token;
-        this.ownerId = ownerId;
+    }
+
+    public boolean isSameToken(String token) {
+        return this.token.equals(token);
     }
 }

--- a/src/main/java/com/server/crews/auth/dto/response/AdminLoginResponse.java
+++ b/src/main/java/com/server/crews/auth/dto/response/AdminLoginResponse.java
@@ -1,4 +1,4 @@
 package com.server.crews.auth.dto.response;
 
-public record AdminLoginResponse(Long adminId, String accessToken) {
+public record AdminLoginResponse(String username, String accessToken) {
 }

--- a/src/main/java/com/server/crews/auth/dto/response/ApplicantLoginResponse.java
+++ b/src/main/java/com/server/crews/auth/dto/response/ApplicantLoginResponse.java
@@ -1,4 +1,4 @@
 package com.server.crews.auth.dto.response;
 
-public record ApplicantLoginResponse(Long applicantId, String accessToken) {
+public record ApplicantLoginResponse(String username, String accessToken) {
 }

--- a/src/main/java/com/server/crews/auth/presentation/AuthController.java
+++ b/src/main/java/com/server/crews/auth/presentation/AuthController.java
@@ -34,7 +34,7 @@ public class AuthController {
     public ResponseEntity<AdminLoginResponse> loginForAdmin(@RequestBody AdminLoginRequest request) {
         AdminLoginResponse loginResponse = authService.loginForAdmin(request);
         RefreshTokenWithValidity refreshTokenWithValidity = refreshTokenService.createRefreshToken(Role.ADMIN,
-                loginResponse.adminId());
+                loginResponse.username());
         ResponseCookie cookie = refreshTokenWithValidity.toCookie();
         return ResponseEntity.status(HttpStatus.OK)
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
@@ -48,7 +48,7 @@ public class AuthController {
     public ResponseEntity<ApplicantLoginResponse> loginForApplicant(@RequestBody ApplicantLoginRequest request) {
         ApplicantLoginResponse loginResponse = authService.loginForApplicant(request);
         RefreshTokenWithValidity refreshTokenWithValidity = refreshTokenService.createRefreshToken(Role.APPLICANT,
-                loginResponse.applicantId());
+                loginResponse.username());
         ResponseCookie cookie = refreshTokenWithValidity.toCookie();
         return ResponseEntity.status(HttpStatus.OK)
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())

--- a/src/main/java/com/server/crews/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/server/crews/auth/repository/RefreshTokenRepository.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
-    void deleteByOwnerId(Long id);
+    void deleteByUsername(String username);
 
-    Optional<RefreshToken> findByToken(String token);
+    Optional<RefreshToken> findByUsername(String username);
 }

--- a/src/main/java/com/server/crews/global/exception/ErrorCode.java
+++ b/src/main/java/com/server/crews/global/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 access token 입니다."),
     USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "존재하지 않는 사용자입니다."),
     UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "권한이 없는 사용자입니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "존재하지 않는 리프레시 토큰입니다."),
 
     RECRUITMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 모집 지원서 양식입니다."),
     APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 지원서입니다."),

--- a/src/main/java/com/server/crews/recruitment/application/RecruitmentService.java
+++ b/src/main/java/com/server/crews/recruitment/application/RecruitmentService.java
@@ -74,7 +74,8 @@ public class RecruitmentService {
         Recruitment recruitment = recruitmentRepository.findByPublisher(publisherId)
                 .orElseThrow(() -> new CrewsException(ErrorCode.RECRUITMENT_NOT_FOUND));
         int applicationCount = applicationRepository.countAllByRecruitment(recruitment);
-        return new RecruitmentStateInProgressResponse(applicationCount, recruitment.getDeadline());
+        return new RecruitmentStateInProgressResponse(applicationCount, recruitment.getDeadline(),
+                recruitment.getCode());
     }
 
     public Optional<RecruitmentDetailsResponse> findRecruitmentDetailsInReady(Long publisherId) {

--- a/src/main/java/com/server/crews/recruitment/dto/response/RecruitmentStateInProgressResponse.java
+++ b/src/main/java/com/server/crews/recruitment/dto/response/RecruitmentStateInProgressResponse.java
@@ -2,5 +2,5 @@ package com.server.crews.recruitment.dto.response;
 
 import java.time.LocalDateTime;
 
-public record RecruitmentStateInProgressResponse(int applicationCount, LocalDateTime deadline) {
+public record RecruitmentStateInProgressResponse(int applicationCount, LocalDateTime deadline, String code) {
 }

--- a/src/test/java/com/server/crews/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/server/crews/auth/application/AuthServiceTest.java
@@ -44,7 +44,7 @@ class AuthServiceTest extends ServiceTest {
         AdminLoginResponse adminLoginResponse = authService.loginForAdmin(request);
 
         // then
-        Optional<Administrator> createdAdmin = administratorRepository.findById(adminLoginResponse.adminId());
+        Optional<Administrator> createdAdmin = administratorRepository.findByClubName(adminLoginResponse.username());
         assertSoftly(softAssertions -> {
             softAssertions.assertThat(createdAdmin).isNotEmpty();
             softAssertions.assertThat(adminLoginResponse.accessToken()).isNotNull();
@@ -62,7 +62,7 @@ class AuthServiceTest extends ServiceTest {
         AdminLoginResponse adminLoginResponse = authService.loginForAdmin(request);
 
         // then
-        Optional<Administrator> createdAdmin = administratorRepository.findById(adminLoginResponse.adminId());
+        Optional<Administrator> createdAdmin = administratorRepository.findByClubName(adminLoginResponse.username());
         assertSoftly(softAssertions -> {
             softAssertions.assertThat(createdAdmin).isNotEmpty();
             softAssertions.assertThat(adminLoginResponse.accessToken()).isNotNull();
@@ -81,7 +81,7 @@ class AuthServiceTest extends ServiceTest {
         ApplicantLoginResponse applicantLoginResponse = authService.loginForApplicant(request);
 
         // then
-        Optional<Applicant> createdApplicant = applicantRepository.findById(applicantLoginResponse.applicantId());
+        Optional<Applicant> createdApplicant = applicantRepository.findByEmail(applicantLoginResponse.username());
         assertSoftly(softAssertions -> {
             softAssertions.assertThat(createdApplicant).isNotEmpty();
             softAssertions.assertThat(applicantLoginResponse.accessToken()).isNotNull();
@@ -99,7 +99,7 @@ class AuthServiceTest extends ServiceTest {
         ApplicantLoginResponse applicantLoginResponse = authService.loginForApplicant(request);
 
         // then
-        Optional<Applicant> createdApplicant = applicantRepository.findById(applicantLoginResponse.applicantId());
+        Optional<Applicant> createdApplicant = applicantRepository.findByEmail(applicantLoginResponse.username());
         assertSoftly(softAssertions -> {
             softAssertions.assertThat(createdApplicant).isNotEmpty();
             softAssertions.assertThat(applicantLoginResponse.accessToken()).isNotNull();


### PR DESCRIPTION
## Description 📒

>주요 변경 사항: 리프레시 토큰의 id를 `auto increment id`에서 `username`으로 변경했다. 리프레시 토큰은 유저(동아리 관리자, 지원자) 당 하나가 저장된다. 리프레시 토큰을 db에 종속적인 `auto increment id`로 식별하는 것보다 `username`으로 식별하는 게 유용하다.

## Issue 💬

#54
