### PR TITLE
ec2 대신 cloudwatch로 로그 저장 및 모니터링

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -76,7 +76,6 @@ jobs:
             docker run -d -p 80:8080 --name crews-server \
               -e JAVA_OPTS="-XX:InitialRAMPercentage=70.0 -XX:MaxRAMPercentage=70.0" \
               -e SPRING_PROFILES_ACTIVE=prod \
-              -v /home/ubuntu/logs:/logs \
               ${{ secrets.DOCKER_SERVER_IMAGE_NAME }}
 
             docker image prune -f

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,7 @@ dependencies {
     implementation 'ch.qos.logback.contrib:logback-jackson:0.1.5'
     implementation 'ch.qos.logback.contrib:logback-json-classic:0.1.5'
     implementation 'net.logstash.logback:logstash-logback-encoder:6.1'
+    implementation "ca.pjer:logback-awslogs-appender:1.6.0"
 }
 
 tasks.named('test') {

--- a/src/main/resources/log/error-appender.xml
+++ b/src/main/resources/log/error-appender.xml
@@ -1,10 +1,18 @@
-<appender name="ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <file>./logs/error.log</file>
+<appender name="ERROR" class="ca.pjer.logback.AwsLogsAppender">
     <filter class="ch.qos.logback.classic.filter.LevelFilter">
         <level>ERROR</level>
         <onMatch>ACCEPT</onMatch>
         <onMismatch>DENY</onMismatch>
     </filter>
+    <logGroupName>/crews-server/error</logGroupName>
+    <logStreamUuidPrefix>crews-server-error-</logStreamUuidPrefix>
+    <logRegion>ap-northeast-2</logRegion>
+    <maxBatchLogEvents>50</maxBatchLogEvents>
+    <maxFlushTimeMillis>30000</maxFlushTimeMillis>
+    <maxBlockTimeMillis>5000</maxBlockTimeMillis>
+    <retentionTimeDays>7</retentionTimeDays>
+    <accessKeyId>${AWS_ACCESS_KEY}</accessKeyId>
+    <secretAccessKey>${AWS_SECRET_KEY}</secretAccessKey>
     <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
         <providers>
             <mdc/>
@@ -22,9 +30,4 @@
             <decorator class="net.logstash.logback.decorate.PrettyPrintingJsonGeneratorDecorator"/>
         </jsonGeneratorDecorator>
     </encoder>
-    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-        <fileNamePattern>error-history.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-        <maxHistory>15</maxHistory>
-        <totalSizeCap>2GB</totalSizeCap>
-    </rollingPolicy>
 </appender>

--- a/src/main/resources/log/info-appender.xml
+++ b/src/main/resources/log/info-appender.xml
@@ -1,10 +1,18 @@
-<appender name="INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <file>./logs/info.log</file>
+<appender name="INFO" class="ca.pjer.logback.AwsLogsAppender">
     <filter class="ch.qos.logback.classic.filter.LevelFilter">
         <level>INFO</level>
         <onMatch>ACCEPT</onMatch>
         <onMismatch>DENY</onMismatch>
     </filter>
+    <logGroupName>/crews-server/info</logGroupName>
+    <logStreamUuidPrefix>crews-server-info-</logStreamUuidPrefix>
+    <logRegion>ap-northeast-2</logRegion>
+    <maxBatchLogEvents>50</maxBatchLogEvents>
+    <maxFlushTimeMillis>30000</maxFlushTimeMillis>
+    <maxBlockTimeMillis>5000</maxBlockTimeMillis>
+    <retentionTimeDays>7</retentionTimeDays>
+    <accessKeyId>${AWS_ACCESS_KEY}</accessKeyId>
+    <secretAccessKey>${AWS_SECRET_KEY}</secretAccessKey>
     <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
         <providers>
             <mdc/>
@@ -23,9 +31,4 @@
             <decorator class="net.logstash.logback.decorate.PrettyPrintingJsonGeneratorDecorator"/>
         </jsonGeneratorDecorator>
     </encoder>
-    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-        <fileNamePattern>info-history.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-        <maxHistory>15</maxHistory>
-        <totalSizeCap>2GB</totalSizeCap>
-    </rollingPolicy>
 </appender>

--- a/src/main/resources/log/logback.xml
+++ b/src/main/resources/log/logback.xml
@@ -20,4 +20,7 @@
         <appender-ref ref="CONSOLE_GENERAL"/>
         <appender-ref ref="CONSOLE_ERROR"/>
     </root>
+
+    <springProperty name="AWS_ACCESS_KEY" source="cloud.aws.credentials.accessKey"/>
+    <springProperty name="AWS_SECRET_KEY" source="cloud.aws.credentials.secretKey"/>
 </configuration>

--- a/src/main/resources/log/warn-appender.xml
+++ b/src/main/resources/log/warn-appender.xml
@@ -1,10 +1,18 @@
-<appender name="WARN" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <file>./logs/warn.log</file>
+<appender name="WARN" class="ca.pjer.logback.AwsLogsAppender">
     <filter class="ch.qos.logback.classic.filter.LevelFilter">
         <level>WARN</level>
         <onMatch>ACCEPT</onMatch>
         <onMismatch>DENY</onMismatch>
     </filter>
+    <logGroupName>/crews-server/warn</logGroupName>
+    <logStreamUuidPrefix>crews-server-warn-</logStreamUuidPrefix>
+    <logRegion>ap-northeast-2</logRegion>
+    <maxBatchLogEvents>50</maxBatchLogEvents>
+    <maxFlushTimeMillis>30000</maxFlushTimeMillis>
+    <maxBlockTimeMillis>5000</maxBlockTimeMillis>
+    <retentionTimeDays>7</retentionTimeDays>
+    <accessKeyId>${AWS_ACCESS_KEY}</accessKeyId>
+    <secretAccessKey>${AWS_SECRET_KEY}</secretAccessKey>
     <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
         <providers>
             <mdc/>
@@ -21,9 +29,4 @@
             <decorator class="net.logstash.logback.decorate.PrettyPrintingJsonGeneratorDecorator"/>
         </jsonGeneratorDecorator>
     </encoder>
-    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-        <fileNamePattern>warn-history.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-        <maxHistory>15</maxHistory>
-        <totalSizeCap>2GB</totalSizeCap>
-    </rollingPolicy>
 </appender>


### PR DESCRIPTION
## Description 📒

>따로 모니터링 서버 구축할 시간이 없다. 서버에 로그 파일을 저장하지 않고 다른 곳에 저장하고 싶다. ➡️ cloudwatch에서 로그그룹 생성하고 모니터링하기

## Issue 💬

#20
