### PR TITLE
api docs 개선

### DIFF
--- a/src/test/java/com/server/crews/api/ApplicationApiDocuments.java
+++ b/src/test/java/com/server/crews/api/ApplicationApiDocuments.java
@@ -2,9 +2,13 @@ package com.server.crews.api;
 
 import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 
-import com.epages.restdocs.apispec.ResourceSnippetParametersBuilder;
+import org.springframework.restdocs.payload.ResponseFieldsSnippet;
 import org.springframework.restdocs.restassured.RestDocumentationFilter;
 
 public class ApplicationApiDocuments {
@@ -12,33 +16,20 @@ public class ApplicationApiDocuments {
 
     public static RestDocumentationFilter SAVE_APPLICATION_200_DOCUMENT() {
         return document(APPLICATION_API + "지원서 저장",
-                new ResourceSnippetParametersBuilder().description("지원서를 저장한다.")
-                        .requestFields(
-                                fieldWithPath(".id")
-                                        .description("지원서 id (최초 저장이 아닐 경우 필요함)")
-                                        .optional(),
-                                fieldWithPath(".studentNumber")
-                                        .description("학번"),
-                                fieldWithPath(".major")
-                                        .description("전공"),
-                                fieldWithPath(".name")
-                                        .description("이름"),
-                                fieldWithPath(".answers")
-                                        .description("답변 목록")
-                                        .optional(),
-                                fieldWithPath(".answers[].answerId")
-                                        .description("답변 id")
-                                        .optional(),
-                                fieldWithPath(".answers[].questionType")
-                                        .description("질문 타입(NARRATIVE, SELECTIVE 중 하나)"),
-                                fieldWithPath(".answers[].questionId")
-                                        .description("질문 id"),
-                                fieldWithPath(".answers[].content")
-                                        .description("서술형 답안 (NARRATIVE 질문의 경우)")
-                                        .optional(),
-                                fieldWithPath(".answers[].choiceId")
-                                        .description("선택지 id (SELECTIVE 질문의 경우)")
-                                        .optional()));
+                "지원서를 저장한다.",
+                requestFields(
+                        fieldWithPath(".id").description("지원서 id (최초 저장이 아닐 경우 필요함)").optional(),
+                        fieldWithPath(".recruitmentCode").description("모집 공고 코드"),
+                        fieldWithPath(".studentNumber").description("학번"),
+                        fieldWithPath(".major").description("전공"),
+                        fieldWithPath(".name").description("지원자 이름"),
+                        fieldWithPath(".answers").description("답변 목록"),
+                        fieldWithPath(".answers[].answerId").description("답변 id").optional(),
+                        fieldWithPath(".answers[].questionType").description("질문 타입(NARRATIVE, SELECTIVE 중 하나)"),
+                        fieldWithPath(".answers[].questionId").description("질문 id"),
+                        fieldWithPath(".answers[].content").description("서술형 답안 (NARRATIVE 질문의 경우)").optional(),
+                        fieldWithPath(".answers[].choiceId").description("선택지 id (SELECTIVE 질문의 경우)").optional()),
+                applicationDetailsResponseFields());
     }
 
     public static RestDocumentationFilter SAVE_APPLICATION_404_DOCUMENT() {
@@ -47,14 +38,17 @@ public class ApplicationApiDocuments {
 
     public static RestDocumentationFilter GET_APPLICATION_200_DOCUMENT() {
         return document(APPLICATION_API + "동아리 관리자 지원서 상세 조회",
-                new ResourceSnippetParametersBuilder().description("동아리 관리자가 지원서 상세 정보를 조회한다.")
-                        .pathParameters(parameterWithName("application-id").description("지원서 id")));
+                "동아리 관리자가 지원서 상세 정보를 조회한다.",
+                pathParameters(
+                        parameterWithName("application-id").description("지원서 id")),
+                applicationDetailsResponseFields());
     }
 
     public static RestDocumentationFilter GET_MY_APPLICATION_200_DOCUMENT() {
         return document(APPLICATION_API + "지원자 지원서 상세 조회",
-                new ResourceSnippetParametersBuilder().description("지원자가 본인의 지원서 상세 정보를 조회한다.")
-                        .queryParameters(parameterWithName("code").description("모집공고 code")));
+                "지원자가 본인의 지원서 상세 정보를 조회한다.",
+                queryParameters(parameterWithName("code").description("모집공고 code")),
+                applicationDetailsResponseFields());
     }
 
     public static RestDocumentationFilter GET_MY_APPLICATION_204_DOCUMENT() {
@@ -63,16 +57,31 @@ public class ApplicationApiDocuments {
 
     public static RestDocumentationFilter GET_APPLICATIONS_200_DOCUMENT() {
         return document(APPLICATION_API + "지원서 목록 조회",
-                new ResourceSnippetParametersBuilder().description("지원서 목록을 조회한다."));
+                "지원서 목록을 조회한다.");
     }
 
     public static RestDocumentationFilter EVALUATE_APPLICATIONS_200_DOCUMENT() {
         return document(APPLICATION_API + "지원서 평가",
-                new ResourceSnippetParametersBuilder().description("지원서를 평가한다.")
-                        .requestFields(fieldWithPath(".passApplicationIds").description("합격 지원서 id 목록")));
+                "지원서를 평가를 저장한다.",
+                requestFields(
+                        fieldWithPath(".passApplicationIds").description("합격 지원서 id 목록")));
     }
 
     public static RestDocumentationFilter EVALUATE_APPLICATIONS_400_DOCUMENT() {
         return document(APPLICATION_API + "평가 및 결과 발표 완료된 모집 공고의 지원서 평가");
+    }
+
+    private static ResponseFieldsSnippet applicationDetailsResponseFields() {
+        return responseFields(
+                fieldWithPath(".id").description("지원서 id"),
+                fieldWithPath(".studentNumber").description("학번"),
+                fieldWithPath(".major").description("전공"),
+                fieldWithPath(".name").description("지원자 이름"),
+                fieldWithPath(".answers").description("답변 목록"),
+                fieldWithPath(".answers[].answerId").description("답변 id"),
+                fieldWithPath(".answers[].type").description("답변 타입(NARRATIVE, SELECTIVE 중 하나)"),
+                fieldWithPath(".answers[].choiceId").description("선택지 id (SELECTIVE 질문의 경우)").optional(),
+                fieldWithPath(".answers[].content").description("서술형 답안 (NARRATIVE 질문의 경우)").optional(),
+                fieldWithPath(".answers[].questionId").description("질문 id"));
     }
 }

--- a/src/test/java/com/server/crews/api/ApplicationApiDocuments.java
+++ b/src/test/java/com/server/crews/api/ApplicationApiDocuments.java
@@ -57,7 +57,13 @@ public class ApplicationApiDocuments {
 
     public static RestDocumentationFilter GET_APPLICATIONS_200_DOCUMENT() {
         return document(APPLICATION_API + "지원서 목록 조회",
-                "지원서 목록을 조회한다.");
+                "지원서 목록을 조회한다.",
+                responseFields(
+                        fieldWithPath("[].id").description("지원서 id"),
+                        fieldWithPath("[].studentNumber").description("학번"),
+                        fieldWithPath("[].name").description("지원자 이름"),
+                        fieldWithPath("[].major").description("전공"),
+                        fieldWithPath("[].outcome").description("지원 결과 (PENDING, PASS, FAIL 중 하나)")));
     }
 
     public static RestDocumentationFilter EVALUATE_APPLICATIONS_200_DOCUMENT() {

--- a/src/test/java/com/server/crews/api/AuthApiDocuments.java
+++ b/src/test/java/com/server/crews/api/AuthApiDocuments.java
@@ -2,9 +2,12 @@ package com.server.crews.api;
 
 import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 
-import com.epages.restdocs.apispec.ResourceSnippetParametersBuilder;
 import org.springframework.restdocs.restassured.RestDocumentationFilter;
 
 public class AuthApiDocuments {
@@ -12,45 +15,28 @@ public class AuthApiDocuments {
 
     public static RestDocumentationFilter LOGIN_ADMIN_200_DOCUMENT() {
         return document(AUTH_API + "동아리 운영진 로그인",
-                new ResourceSnippetParametersBuilder().description("동아리 운영진(admin)이 로그인한다.")
-                        .requestFields(
-                                fieldWithPath(".clubName")
-                                        .description("동아리 이름"),
-                                fieldWithPath(".password")
-                                        .description("비밀번호"))
-                        .responseFields(
-                                fieldWithPath(".adminId")
-                                        .description("운영진 id"),
-                                fieldWithPath(".accessToken")
-                                        .description("access token"),
-                                fieldWithPath(".recruitmentProgress")
-                                        .description(
-                                                "모집 공고 상태 (READY: 모집 공고 작성 중, IN_PROGRESS: 모집 중, COMPLETION: 평가 중, ANNOUNCED: 이메일 전송 완료)"),
-                                fieldWithPath(".recruitmentId")
-                                        .description("모집 공고 id (없다면 null)"))
-                        .responseHeaders(headerWithName("Cookie")
-                                .description("리프레시 토큰")));
+                "동아리 운영진(admin)이 로그인한다.",
+                requestFields(
+                        fieldWithPath(".clubName").description("동아리 이름"),
+                        fieldWithPath(".password").description("비밀번호")),
+                responseFields(
+                        fieldWithPath(".username").description("동아리 이름"),
+                        fieldWithPath(".accessToken").description("access token")),
+                responseHeaders(
+                        headerWithName("Set-Cookie").description("리프레시 토큰")));
     }
 
     public static RestDocumentationFilter LOGIN_APPLICANT_200_DOCUMENT() {
         return document(AUTH_API + "지원자 로그인",
-                new ResourceSnippetParametersBuilder().description("지원자(applicant)가 로그인한다.")
-                        .requestFields(
-                                fieldWithPath(".recruitmentCode")
-                                        .description("모집 공고 코드"),
-                                fieldWithPath(".email")
-                                        .description("이메일"),
-                                fieldWithPath(".password")
-                                        .description("비밀번호"))
-                        .responseFields(
-                                fieldWithPath(".applicantId")
-                                        .description("지원자 id"),
-                                fieldWithPath(".accessToken")
-                                        .description("access token"),
-                                fieldWithPath(".recruitmentProgress")
-                                        .description("모집 공고 상태 (IN_PROGRESS: 모집 중, COMPLETION: 평가 중)"),
-                                fieldWithPath(".applicationId")
-                                        .description("지원서 id (없다면 null)")));
+                "지원자(applicant)가 로그인한다.",
+                requestFields(
+                        fieldWithPath(".email").description("이메일"),
+                        fieldWithPath(".password").description("비밀번호")),
+                responseFields(
+                        fieldWithPath(".username").description("지원자 email"),
+                        fieldWithPath(".accessToken").description("access token")),
+                responseHeaders(
+                        headerWithName("Set-Cookie").description("리프레시 토큰")));
     }
 
     public static RestDocumentationFilter LOGIN_ADMIN_400_DOCUMENT() {
@@ -59,14 +45,14 @@ public class AuthApiDocuments {
 
     public static RestDocumentationFilter REFRESH_TOKEN_200_DOCUMENT() {
         return document(AUTH_API + "토큰 재발급",
-                new ResourceSnippetParametersBuilder().description("access token을 재발급 받는다.")
-                        .requestHeaders(headerWithName("Cookie")
-                                .description("리프레시 토큰")));
+                "access token을 재발급 받는다.",
+                requestHeaders(
+                        headerWithName("Cookie").description("리프레시 토큰")));
     }
 
     public static RestDocumentationFilter LOGOUT_200_DOCUMENT() {
         return document(AUTH_API + "로그아웃",
-                new ResourceSnippetParametersBuilder().description("로그아웃한다."));
+                "로그아웃한다.");
     }
 
     public static RestDocumentationFilter AUTHORIZE_401_DOCUMENT() {

--- a/src/test/java/com/server/crews/api/AuthApiDocuments.java
+++ b/src/test/java/com/server/crews/api/AuthApiDocuments.java
@@ -47,12 +47,16 @@ public class AuthApiDocuments {
         return document(AUTH_API + "토큰 재발급",
                 "access token을 재발급 받는다.",
                 requestHeaders(
-                        headerWithName("Cookie").description("리프레시 토큰")));
+                        headerWithName("Cookie").description("리프레시 토큰")),
+                responseFields(
+                        fieldWithPath(".accessToken").description("access token")));
     }
 
     public static RestDocumentationFilter LOGOUT_200_DOCUMENT() {
         return document(AUTH_API + "로그아웃",
-                "로그아웃한다.");
+                "로그아웃한다.",
+                responseHeaders(
+                        headerWithName("Set-Cookie").description("만료된 쿠키")));
     }
 
     public static RestDocumentationFilter AUTHORIZE_401_DOCUMENT() {

--- a/src/test/java/com/server/crews/api/AuthApiTest.java
+++ b/src/test/java/com/server/crews/api/AuthApiTest.java
@@ -134,7 +134,7 @@ public class AuthApiTest extends ApiTest {
         // when
         ExtractableResponse<Response> response = RestAssured.given(spec).log().all()
                 .filter(AuthApiDocuments.REFRESH_TOKEN_200_DOCUMENT())
-                .cookie("refreshToken", refreshToken)
+                .header("Cookie", "refreshToken=" + refreshToken)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(adminLoginRequest)
                 .when().post("/auth/refresh")

--- a/src/test/java/com/server/crews/api/RecruitmentApiDocuments.java
+++ b/src/test/java/com/server/crews/api/RecruitmentApiDocuments.java
@@ -2,9 +2,12 @@ package com.server.crews.api;
 
 import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 
-import com.epages.restdocs.apispec.ResourceSnippetParametersBuilder;
+import org.springframework.restdocs.payload.ResponseFieldsSnippet;
 import org.springframework.restdocs.restassured.RestDocumentationFilter;
 
 public class RecruitmentApiDocuments {
@@ -12,74 +15,49 @@ public class RecruitmentApiDocuments {
 
     public static RestDocumentationFilter SAVE_RECRUITMENT_200_DOCUMENT() {
         return document(RECRUITMENT_API + "모집 공고 저장",
-                new ResourceSnippetParametersBuilder().description("모집 공고를 저장한다.")
-                        .requestFields(
-                                fieldWithPath(".id")
-                                        .description("모집 공고 id (최초 저장이 아닐 경우 필요함)")
-                                        .optional(),
-                                fieldWithPath(".title")
-                                        .description("모집 공고 제목"),
-                                fieldWithPath(".description")
-                                        .description("모집 공고 설명")
-                                        .optional(),
-                                fieldWithPath(".deadline")
-                                        .description("모집 마감일"),
-                                fieldWithPath(".sections")
-                                        .description("섹션 목록 (없을 경우 빈 리스트)"),
-                                fieldWithPath(".sections[].id")
-                                        .description("섹션 id (최초 저장이 아닐 경우 필요함)")
-                                        .optional(),
-                                fieldWithPath(".sections[].name")
-                                        .description("섹션 이름"),
-                                fieldWithPath(".sections[].description")
-                                        .description("섹션 설명")
-                                        .optional(),
-                                fieldWithPath(".sections[].questions")
-                                        .description("질문 목록 (없을 경우 빈 리스트)"),
-                                fieldWithPath(".sections[].questions[].id")
-                                        .description("질문 id (최초 저장이 아닐 경우 필요함)")
-                                        .optional(),
-                                fieldWithPath(".sections[].questions[].type")
-                                        .description("질문 타입(NARRATIVE, SELECTIVE 중 하나)"),
-                                fieldWithPath(".sections[].questions[].content")
-                                        .description("질문 내용"),
-                                fieldWithPath(".sections[].questions[].necessity")
-                                        .description("필수여부"),
-                                fieldWithPath(".sections[].questions[].order")
-                                        .description("질문순서 (오름차순으로 정렬됨)"),
-                                fieldWithPath(".sections[].questions[].wordLimit")
-                                        .description("NARRATIVE 질문의 글자 수 제한")
-                                        .optional(),
-                                fieldWithPath(".sections[].questions[].minimumSelection")
-                                        .description(
-                                                "SELECTIVE 질문의 최소 선택 개수")
-                                        .optional(),
-                                fieldWithPath(".sections[].questions[].maximumSelection")
-                                        .description("SELECTIVE 질문의 최대 선택 개수")
-                                        .optional(),
-                                fieldWithPath(".sections[].questions[].choices")
-                                        .description("SELECTIVE 질문의 선택지 목록 (없을 경우 빈 리스트)"),
-                                fieldWithPath(".sections[].questions[].choices[].id")
-                                        .description("선택지 id (최초 저장이 아닐 경우 필요함)")
-                                        .optional(),
-                                fieldWithPath(".sections[].questions[].choices[].content")
-                                        .description("선택지 내용")));
+                "모집 공고를 저장한다.",
+                requestFields(
+                        fieldWithPath(".id").description("모집 공고 id (최초 저장이 아닐 경우 필요함)").optional(),
+                        fieldWithPath(".title").description("모집 공고 제목"),
+                        fieldWithPath(".description").description("모집 공고 설명").optional(),
+                        fieldWithPath(".deadline").description("모집 마감일"),
+                        fieldWithPath(".sections").description("섹션 목록 (없을 경우 빈 리스트)"),
+                        fieldWithPath(".sections[].id").description("섹션 id (최초 저장이 아닐 경우 필요함)").optional(),
+                        fieldWithPath(".sections[].name").description("섹션 이름"),
+                        fieldWithPath(".sections[].description").description("섹션 설명").optional(),
+                        fieldWithPath(".sections[].questions").description("질문 목록 (없을 경우 빈 리스트)"),
+                        fieldWithPath(".sections[].questions[].id").description("질문 id (최초 저장이 아닐 경우 필요함)").optional(),
+                        fieldWithPath(".sections[].questions[].type").description("질문 타입(NARRATIVE, SELECTIVE 중 하나)"),
+                        fieldWithPath(".sections[].questions[].content").description("질문 내용"),
+                        fieldWithPath(".sections[].questions[].necessity").description("필수여부"),
+                        fieldWithPath(".sections[].questions[].order").description("질문순서 (오름차순으로 정렬됨)"),
+                        fieldWithPath(".sections[].questions[].wordLimit").description("NARRATIVE 질문의 글자 수 제한")
+                                .optional(),
+                        fieldWithPath(".sections[].questions[].minimumSelection").description("SELECTIVE 질문의 최소 선택 개수")
+                                .optional(),
+                        fieldWithPath(".sections[].questions[].maximumSelection").description("SELECTIVE 질문의 최대 선택 개수")
+                                .optional(),
+                        fieldWithPath(".sections[].questions[].choices").description(
+                                "SELECTIVE 질문의 선택지 목록 (없을 경우 빈 리스트)"),
+                        fieldWithPath(".sections[].questions[].choices[].id").description("선택지 id (최초 저장이 아닐 경우 필요함)")
+                                .optional(),
+                        fieldWithPath(".sections[].questions[].choices[].content").description("선택지 내용")),
+                recruitmentDetailsResponseFields());
     }
 
     public static RestDocumentationFilter SAVE_RECRUITMENT_400_DOCUMENT() {
         return document(RECRUITMENT_API + "잘못된 마감일의 모집 공고 저장",
-                new ResourceSnippetParametersBuilder()
-                        .requestFields(
-                                fieldWithPath(".id").description("모집 공고 id"),
-                                fieldWithPath(".title").description("모집 공고 제목"),
-                                fieldWithPath(".description").description("모집 공고 설명"),
-                                fieldWithPath(".sections").description("섹션 목록"),
-                                fieldWithPath(".deadline").description("현재 날짜 이후여야 하는 모집 마감일")));
+                requestFields(
+                        fieldWithPath(".id").description("모집 공고 id"),
+                        fieldWithPath(".title").description("모집 공고 제목"),
+                        fieldWithPath(".description").description("모집 공고 설명"),
+                        fieldWithPath(".sections").description("섹션 목록"),
+                        fieldWithPath(".deadline").description("현재 날짜 이후여야 하는 모집 마감일")));
     }
 
     public static RestDocumentationFilter START_RECRUITMENT_200_DOCUMENT() {
         return document(RECRUITMENT_API + "모집 시작",
-                new ResourceSnippetParametersBuilder().description("모집을 시작한다."));
+                "모집을 시작한다.");
     }
 
     public static RestDocumentationFilter START_RECRUITMENT_400_DOCUMENT() {
@@ -88,12 +66,13 @@ public class RecruitmentApiDocuments {
 
     public static RestDocumentationFilter GET_RECRUITMENT_STATUS_200_DOCUMENT() {
         return document(RECRUITMENT_API + "모집 중 지원 상태를 조회",
-                new ResourceSnippetParametersBuilder().description("모집 중 지원 상태를 조회한다."));
+                "모집 중 지원 상태를 조회한다.");
     }
 
     public static RestDocumentationFilter GET_READY_RECRUITMENT_200_DOCUMENT() {
         return document(RECRUITMENT_API + "작성중인 모집 공고(지원서 양식) 상세 조회",
-                new ResourceSnippetParametersBuilder().description("작성중인 모집 공고(지원서 양식) 상세 정보를 조회한다."));
+                "작성중인 모집 공고(지원서 양식) 상세 정보를 조회한다.",
+                recruitmentDetailsResponseFields());
     }
 
     public static RestDocumentationFilter GET_READY_RECRUITMENT_204_DOCUMENT() {
@@ -102,28 +81,60 @@ public class RecruitmentApiDocuments {
 
     public static RestDocumentationFilter GET_RECRUITMENT_BY_CODE_200_DOCUMENT() {
         return document(RECRUITMENT_API + "모집 공고 코드 확인",
-                new ResourceSnippetParametersBuilder().description("코드로 모집공고 상세 정보를 조회한다.")
-                        .queryParameters(parameterWithName("code").description("모집 공고 코드")));
+                "코드로 모집공고 상세 정보를 조회한다.",
+                queryParameters(
+                        parameterWithName("code").description("모집 공고 코드")),
+                recruitmentDetailsResponseFields());
     }
 
     public static RestDocumentationFilter GET_RECRUITMENT_BY_CODE_400_DOCUMENT() {
-        return document(RECRUITMENT_API + "준비 중인 모집 공고 코드 확인",
-                new ResourceSnippetParametersBuilder().queryParameters(parameterWithName("code").description("모집 공고 코드")));
+        return document(RECRUITMENT_API + "준비 중인 모집 공고 코드 확인");
     }
 
     public static RestDocumentationFilter GET_RECRUITMENT_PROGRESS_200_DOCUMENT() {
         return document(RECRUITMENT_API + "모집 공고 단계 조회",
-                new ResourceSnippetParametersBuilder().description("모집공고의 단계를 조회한다."));
+                "모집공고의 단계를 조회한다.");
     }
 
     public static RestDocumentationFilter UPDATE_RECRUITMENT_DEADLINE_200_DOCUMENT() {
         return document(RECRUITMENT_API + "모집 마감일 변경",
-                new ResourceSnippetParametersBuilder().description("모집 마감일을 변경한다.")
-                        .requestFields(fieldWithPath(".deadline").description("변경된 마감일")));
+                "모집 마감일을 변경한다.",
+                requestFields(
+                        fieldWithPath(".deadline").description("변경된 마감일")));
     }
 
     public static RestDocumentationFilter SEND_OUTCOME_EMAIL_200_REQUEST() {
         return document(RECRUITMENT_API + "지원 결과 메일 전송",
-                new ResourceSnippetParametersBuilder().description("지원 결과 메일을 전송한다."));
+                "지원 결과 메일을 전송한다.");
+    }
+
+    private static ResponseFieldsSnippet recruitmentDetailsResponseFields() {
+        return responseFields(
+                fieldWithPath(".id").description("모집 공고 id (최초 저장이 아닐 경우 필요함)"),
+                fieldWithPath(".title").description("모집 공고 제목"),
+                fieldWithPath(".description").description("모집 공고 설명").optional(),
+                fieldWithPath(".deadline").description("모집 마감일"),
+                fieldWithPath(".code").description("모집 공고 코드"),
+                fieldWithPath(".recruitmentProgress").description("모집 공고 progress 상태"),
+                fieldWithPath(".sections").description("섹션 목록 (없을 경우 빈 리스트)"),
+                fieldWithPath(".sections[].id").description("섹션 id"),
+                fieldWithPath(".sections[].name").description("섹션 이름"),
+                fieldWithPath(".sections[].description").description("섹션 설명").optional(),
+                fieldWithPath(".sections[].questions").description("질문 목록 (없을 경우 빈 리스트)"),
+                fieldWithPath(".sections[].questions[].id").description("질문 id"),
+                fieldWithPath(".sections[].questions[].type").description("질문 타입(NARRATIVE, SELECTIVE 중 하나)"),
+                fieldWithPath(".sections[].questions[].content").description("질문 내용"),
+                fieldWithPath(".sections[].questions[].necessity").description("필수여부"),
+                fieldWithPath(".sections[].questions[].order").description("질문순서 (오름차순으로 정렬됨)"),
+                fieldWithPath(".sections[].questions[].wordLimit").description("NARRATIVE 질문의 글자 수 제한")
+                        .optional(),
+                fieldWithPath(".sections[].questions[].minimumSelection").description("SELECTIVE 질문의 최소 선택 개수")
+                        .optional(),
+                fieldWithPath(".sections[].questions[].maximumSelection").description("SELECTIVE 질문의 최대 선택 개수")
+                        .optional(),
+                fieldWithPath(".sections[].questions[].choices").description(
+                        "SELECTIVE 질문의 선택지 목록 (없을 경우 빈 리스트)"),
+                fieldWithPath(".sections[].questions[].choices[].id").description("선택지 id"),
+                fieldWithPath(".sections[].questions[].choices[].content").description("선택지 내용"));
     }
 }

--- a/src/test/java/com/server/crews/api/RecruitmentApiDocuments.java
+++ b/src/test/java/com/server/crews/api/RecruitmentApiDocuments.java
@@ -66,7 +66,11 @@ public class RecruitmentApiDocuments {
 
     public static RestDocumentationFilter GET_RECRUITMENT_STATUS_200_DOCUMENT() {
         return document(RECRUITMENT_API + "모집 중 지원 상태를 조회",
-                "모집 중 지원 상태를 조회한다.");
+                "모집 중 지원 상태를 조회한다.",
+                responseFields(
+                        fieldWithPath("applicationCount").description("지원서 수"),
+                        fieldWithPath("deadline").description("모집 마감 기한"),
+                        fieldWithPath("code").description("모집 공고 코드")));
     }
 
     public static RestDocumentationFilter GET_READY_RECRUITMENT_200_DOCUMENT() {
@@ -80,7 +84,7 @@ public class RecruitmentApiDocuments {
     }
 
     public static RestDocumentationFilter GET_RECRUITMENT_BY_CODE_200_DOCUMENT() {
-        return document(RECRUITMENT_API + "모집 공고 코드 확인",
+        return document(RECRUITMENT_API + "코드로 모집 공고 조회",
                 "코드로 모집공고 상세 정보를 조회한다.",
                 queryParameters(
                         parameterWithName("code").description("모집 공고 코드")),
@@ -88,12 +92,14 @@ public class RecruitmentApiDocuments {
     }
 
     public static RestDocumentationFilter GET_RECRUITMENT_BY_CODE_400_DOCUMENT() {
-        return document(RECRUITMENT_API + "준비 중인 모집 공고 코드 확인");
+        return document(RECRUITMENT_API + "준비 중인 모집 공고를 코드로 조회");
     }
 
     public static RestDocumentationFilter GET_RECRUITMENT_PROGRESS_200_DOCUMENT() {
         return document(RECRUITMENT_API + "모집 공고 단계 조회",
-                "모집공고의 단계를 조회한다.");
+                "모집공고의 단계를 조회한다.",
+                responseFields(
+                        fieldWithPath(".recruitmentProgress").description("모집 공고 단계(Progress)")));
     }
 
     public static RestDocumentationFilter UPDATE_RECRUITMENT_DEADLINE_200_DOCUMENT() {


### PR DESCRIPTION
## Description 📒

>드디어 멀쩡한 api docs 완성

### 기존 문제 상황
아래와 같이 description을 추가하면 스니펫들이 제대로 OSA 파일(json)로 변환되지 않았다. 
```java
    public static RestDocumentationFilter SAVE_RECRUITMENT_200_DOCUMENT() {
        return document(RECRUITMENT_API + "모집 공고 저장",
                "모집 공고를 저장한다.", // description
                requestFields(
                        fieldWithPath(".id").description("모집 공고 id (최초 저장이 아닐 경우 필요함)").optional(),
                        fieldWithPath(".title").description("모집 공고 제목"),
                        fieldWithPath(".description").description("모집 공고 설명").optional()
```
### 해결 방법 설명
[오픈소스 깃허브](https://github.com/ePages-de/restdocs-api-spec?tab=readme-ov-file#rest-assured-based-tests)를 봐도 아래와 같이 description과 requestFields을 같이 설정할 수 있다.
```java
         document("{method-name}",
                "The API description",
                requestParameters(
                        parameterWithName("param").description("the param")
                ),
                responseFields(
                        fieldWithPath("doc.timestamp").description("Creation timestamp")
                )
```
메소드 시그니처는 아래와 같다. (`Kotlin`이다 🥲)
```kotlin
  public final fun document(identifier: kotlin.String, description: kotlin.String? = COMPILED_CODE, summary: kotlin.String? = COMPILED_CODE, privateResource: kotlin.Boolean = COMPILED_CODE, deprecated: kotlin.Boolean = COMPILED_CODE, requestPreprocessor: org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor? = COMPILED_CODE, responsePreprocessor: org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor? = COMPILED_CODE, snippetFilter: java.util.function.Function<kotlin.collections.List<org.springframework.restdocs.snippet.Snippet>, kotlin.collections.List<org.springframework.restdocs.snippet.Snippet>> = COMPILED_CODE, vararg snippets: org.springframework.restdocs.snippet.Snippet): org.springframework.restdocs.restassured.RestDocumentationFilter { /* compiled code */ }
```
스니펫들이 가변인자(`vararg`)다. 아주 정확하게 이해하지는 못했지만 description 인자가 가변 인자 스니펫들보다 우선 적용되어, 나머지 스니펫들이 적용되지 않았다. response가 있는 api라면 스니펫까지 추가(`responseFields`)하니 잘 작동되었다. 코틀린 코드라 디버깅도 안돌아가는데 코틀린 공부를 해야 하나 😅

## Issue 💬

#63
