### PR TITLE
지원서 저장 로직 dto 의존 제거, dto 필드 변경

### DIFF
--- a/src/main/java/com/server/crews/applicant/application/AnswerManager.java
+++ b/src/main/java/com/server/crews/applicant/application/AnswerManager.java
@@ -1,0 +1,22 @@
+package com.server.crews.applicant.application;
+
+public abstract class AnswerManager<Q, A> {
+    protected Q question;
+    protected A previousAnswer;
+    protected A newAnswer;
+
+    public AnswerManager(Q question, A previousAnswer, A newAnswer) {
+        this.question = question;
+        this.previousAnswer = previousAnswer;
+        this.newAnswer = newAnswer;
+    }
+
+    public A getValidatedAnswers() {
+        validate();
+        return synchronizeWithPreviousAnswers();
+    }
+
+   protected abstract void validate();
+
+    protected abstract A synchronizeWithPreviousAnswers();
+}

--- a/src/main/java/com/server/crews/applicant/application/ApplicationAnswerReader.java
+++ b/src/main/java/com/server/crews/applicant/application/ApplicationAnswerReader.java
@@ -5,6 +5,7 @@ import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toMap;
 
 import com.server.crews.applicant.domain.Application;
+import com.server.crews.applicant.domain.SelectiveAnswer;
 import com.server.crews.applicant.dto.response.AnswerResponse;
 import com.server.crews.applicant.dto.response.ApplicationDetailsResponse;
 import com.server.crews.applicant.dto.response.SectionAnswerResponse;
@@ -16,6 +17,7 @@ import com.server.crews.recruitment.domain.QuestionType;
 import com.server.crews.recruitment.domain.SelectiveQuestion;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -107,9 +109,11 @@ public class ApplicationAnswerReader {
 
     private Map<Long, AnswerResponse> selectiveAnswerResponsesByQuestionIdInApplication() {
         return application.getSelectiveAnswersByQuestionId()
-                .entrySet()
+                .values()
                 .stream()
-                .map(entry -> AnswerMapper.selectiveAnswerToAnswerResponse(entry.getValue()))
+                .peek(selectiveAnswers -> Collections.sort(selectiveAnswers,
+                        Comparator.comparingLong(SelectiveAnswer::getChoiceId)))
+                .map(selectiveAnswers -> AnswerMapper.selectiveAnswerToAnswerResponse(selectiveAnswers))
                 .collect(toMap(AnswerResponse::questionId, identity()));
     }
 

--- a/src/main/java/com/server/crews/applicant/application/ApplicationAnswerReader.java
+++ b/src/main/java/com/server/crews/applicant/application/ApplicationAnswerReader.java
@@ -1,0 +1,116 @@
+package com.server.crews.applicant.application;
+
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toMap;
+
+import com.server.crews.applicant.domain.Application;
+import com.server.crews.applicant.dto.response.AnswerResponse;
+import com.server.crews.applicant.dto.response.ApplicationDetailsResponse;
+import com.server.crews.applicant.dto.response.SectionAnswerResponse;
+import com.server.crews.applicant.util.AnswerMapper;
+import com.server.crews.applicant.util.ApplicationMapper;
+import com.server.crews.recruitment.domain.NarrativeQuestion;
+import com.server.crews.recruitment.domain.OrderedQuestion;
+import com.server.crews.recruitment.domain.QuestionType;
+import com.server.crews.recruitment.domain.SelectiveQuestion;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class ApplicationAnswerReader {
+    private final LinkedHashMap<Long, List<OrderedQuestion>> orderedQuestionsByOrderedSectionId;
+    private final Application application;
+
+    public ApplicationAnswerReader(List<NarrativeQuestion> narrativeQuestions,
+                                   List<SelectiveQuestion> selectiveQuestions,
+                                   Application application) {
+        this.orderedQuestionsByOrderedSectionId = orderedQuestionsFrom(narrativeQuestions, selectiveQuestions);
+        this.application = application;
+    }
+
+    private LinkedHashMap<Long, List<OrderedQuestion>> orderedQuestionsFrom(List<NarrativeQuestion> narrativeQuestions,
+                                                                            List<SelectiveQuestion> selectiveQuestions) {
+        Map<Long, List<OrderedQuestion>> narrativeQuestionsBySectionId = groupBySectionId(narrativeQuestions);
+        Map<Long, List<OrderedQuestion>> selectiveQuestionsBySectionId = groupBySectionId(selectiveQuestions);
+
+        List<Long> orderedSectionIds = getOrderedSectionIds(narrativeQuestionsBySectionId.keySet(),
+                selectiveQuestionsBySectionId.keySet());
+
+        LinkedHashMap<Long, List<OrderedQuestion>> orderedQuestionsBySectionId = new LinkedHashMap<>();
+        for (Long sectionId : orderedSectionIds) {
+            List<OrderedQuestion> narrativeOrderedQuestions = narrativeQuestionsBySectionId.getOrDefault(sectionId,
+                    Collections.emptyList());
+            List<OrderedQuestion> selectiveOrderedQuestions = selectiveQuestionsBySectionId.getOrDefault(sectionId,
+                    Collections.emptyList());
+
+            List<OrderedQuestion> orderedQuestions = new ArrayList<>(narrativeOrderedQuestions);
+            orderedQuestions.addAll(selectiveOrderedQuestions);
+            Collections.sort(orderedQuestions);
+
+            orderedQuestionsBySectionId.put(sectionId, orderedQuestions);
+        }
+
+        return orderedQuestionsBySectionId;
+    }
+
+    private <T extends OrderedQuestion> Map<Long, List<OrderedQuestion>> groupBySectionId(List<T> questions) {
+        return questions.stream()
+                .collect(groupingBy(OrderedQuestion::getSectionId));
+    }
+
+    private List<Long> getOrderedSectionIds(Set<Long> sectionIdsInNarrativeQuestions,
+                                            Set<Long> sectionIdsInSelectiveQuestions) {
+        Set<Long> sectionIds = new HashSet<>(sectionIdsInNarrativeQuestions);
+        sectionIds.addAll(sectionIdsInSelectiveQuestions);
+
+        List<Long> sortedSectionIds = new ArrayList<>(sectionIds);
+        Collections.sort(sortedSectionIds);
+
+        return sortedSectionIds;
+    }
+
+    public ApplicationDetailsResponse readBySection() {
+        Map<Long, AnswerResponse> narrativeAnswerResponsesByQuestionId = narrativeAnswerResponsesByQuestionIdInApplication();
+        Map<Long, AnswerResponse> selectiveAnswerResponsesByQuestionId = selectiveAnswerResponsesByQuestionIdInApplication();
+
+        List<SectionAnswerResponse> sectionAnswerResponse = new ArrayList<>();
+        for (Map.Entry<Long, List<OrderedQuestion>> entry : orderedQuestionsByOrderedSectionId.entrySet()) {
+            List<AnswerResponse> answerResponses = new ArrayList<>();
+
+            for (OrderedQuestion question : entry.getValue()) {
+                Long questionId = question.getId();
+                if (narrativeAnswerResponsesByQuestionId.containsKey(questionId)
+                        && question.getQuestionType() == QuestionType.NARRATIVE) {
+                    answerResponses.add(narrativeAnswerResponsesByQuestionId.get(questionId));
+                }
+                if (selectiveAnswerResponsesByQuestionId.containsKey(questionId)
+                        && question.getQuestionType() == QuestionType.SELECTIVE) {
+                    answerResponses.add(selectiveAnswerResponsesByQuestionId.get(questionId));
+                }
+            }
+
+            sectionAnswerResponse.add(new SectionAnswerResponse(entry.getKey(), answerResponses));
+        }
+
+        return ApplicationMapper.applicationToApplicationDetailsResponse(application, sectionAnswerResponse);
+    }
+
+    private Map<Long, AnswerResponse> narrativeAnswerResponsesByQuestionIdInApplication() {
+        return application.getNarrativeAnswers().stream()
+                .map(AnswerMapper::narrativeAnswerToAnswerResponse)
+                .collect(toMap(AnswerResponse::questionId, identity()));
+    }
+
+    private Map<Long, AnswerResponse> selectiveAnswerResponsesByQuestionIdInApplication() {
+        return application.getSelectiveAnswersByQuestionId()
+                .entrySet()
+                .stream()
+                .map(entry -> AnswerMapper.selectiveAnswerToAnswerResponse(entry.getValue()))
+                .collect(toMap(AnswerResponse::questionId, identity()));
+    }
+}

--- a/src/main/java/com/server/crews/applicant/application/ApplicationAnswerReader.java
+++ b/src/main/java/com/server/crews/applicant/application/ApplicationAnswerReader.java
@@ -111,9 +111,10 @@ public class ApplicationAnswerReader {
         return application.getSelectiveAnswersByQuestionId()
                 .values()
                 .stream()
-                .peek(selectiveAnswers -> Collections.sort(selectiveAnswers,
-                        Comparator.comparingLong(SelectiveAnswer::getChoiceId)))
-                .map(selectiveAnswers -> AnswerMapper.selectiveAnswerToAnswerResponse(selectiveAnswers))
+                .map(selectiveAnswers -> {
+                    selectiveAnswers.sort(Comparator.comparingLong(SelectiveAnswer::getChoiceId));
+                    return AnswerMapper.selectiveAnswerToAnswerResponse(selectiveAnswers);
+                })
                 .collect(toMap(AnswerResponse::questionId, identity()));
     }
 

--- a/src/main/java/com/server/crews/applicant/application/ApplicationAnswerReader.java
+++ b/src/main/java/com/server/crews/applicant/application/ApplicationAnswerReader.java
@@ -83,14 +83,13 @@ public class ApplicationAnswerReader {
             List<AnswerResponse> answerResponses = new ArrayList<>();
 
             for (OrderedQuestion question : entry.getValue()) {
-                Long questionId = question.getId();
-                if (narrativeAnswerResponsesByQuestionId.containsKey(questionId)
-                        && question.getQuestionType() == QuestionType.NARRATIVE) {
-                    answerResponses.add(narrativeAnswerResponsesByQuestionId.get(questionId));
+                if (question.getQuestionType() == QuestionType.NARRATIVE) {
+                    AnswerResponse answerResponse = getAnswerResponse(narrativeAnswerResponsesByQuestionId, question);
+                    answerResponses.add(answerResponse);
                 }
-                if (selectiveAnswerResponsesByQuestionId.containsKey(questionId)
-                        && question.getQuestionType() == QuestionType.SELECTIVE) {
-                    answerResponses.add(selectiveAnswerResponsesByQuestionId.get(questionId));
+                if (question.getQuestionType() == QuestionType.SELECTIVE) {
+                    AnswerResponse answerResponse = getAnswerResponse(selectiveAnswerResponsesByQuestionId, question);
+                    answerResponses.add(answerResponse);
                 }
             }
 
@@ -112,5 +111,14 @@ public class ApplicationAnswerReader {
                 .stream()
                 .map(entry -> AnswerMapper.selectiveAnswerToAnswerResponse(entry.getValue()))
                 .collect(toMap(AnswerResponse::questionId, identity()));
+    }
+
+    private AnswerResponse getAnswerResponse(Map<Long, AnswerResponse> answerResponsesByQuestionId,
+                                             OrderedQuestion question) {
+        Long questionId = question.getId();
+        if (answerResponsesByQuestionId.containsKey(questionId)) {
+            return answerResponsesByQuestionId.get(questionId);
+        }
+        return new AnswerResponse(questionId, null, null, question.getQuestionType());
     }
 }

--- a/src/main/java/com/server/crews/applicant/application/ApplicationForm.java
+++ b/src/main/java/com/server/crews/applicant/application/ApplicationForm.java
@@ -1,0 +1,81 @@
+package com.server.crews.applicant.application;
+
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toMap;
+
+import com.server.crews.applicant.domain.Application;
+import com.server.crews.applicant.domain.NarrativeAnswer;
+import com.server.crews.applicant.domain.SelectiveAnswer;
+import com.server.crews.recruitment.domain.NarrativeQuestion;
+import com.server.crews.recruitment.domain.SelectiveQuestion;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class ApplicationForm {
+    private List<NarrativeQuestion> narrativeQuestions;
+    private List<SelectiveQuestion> selectiveQuestions;
+    private Map<Long, NarrativeAnswer> previousNarrativeAnswersByQuestionId;
+    private Map<Long, List<SelectiveAnswer>> previousSelectiveAnswersByQuestionId;
+
+    public ApplicationForm(List<NarrativeQuestion> narrativeQuestions, List<SelectiveQuestion> selectiveQuestions) {
+        this.narrativeQuestions = narrativeQuestions;
+        this.selectiveQuestions = selectiveQuestions;
+        this.previousNarrativeAnswersByQuestionId = new HashMap<>();
+        this.previousSelectiveAnswersByQuestionId = new HashMap<>();
+    }
+
+    public ApplicationForm(List<NarrativeQuestion> narrativeQuestions, List<SelectiveQuestion> selectiveQuestions,
+                           Application previousApplication) {
+        this.narrativeQuestions = narrativeQuestions;
+        this.selectiveQuestions = selectiveQuestions;
+        this.previousNarrativeAnswersByQuestionId = previousApplication.getNarrativeAnswersByQuestionId();
+        this.previousSelectiveAnswersByQuestionId = previousApplication.getSelectiveAnswersByQuestionId();
+    }
+
+    public List<NarrativeAnswer> writeNarrativeAnswers(List<NarrativeAnswer> newNarrativeAnswers) {
+        Map<Long, NarrativeAnswer> newNarrativeAnswersByQuestionId = newNarrativeAnswers.stream()
+                .collect(toMap(NarrativeAnswer::getQuestionId, identity()));
+
+        return narrativeQuestions.stream()
+                .map(question -> writerNarrativeAnswer(question, newNarrativeAnswersByQuestionId.get(question.getId())))
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    private NarrativeAnswer writerNarrativeAnswer(NarrativeQuestion question, NarrativeAnswer newAnswer) {
+        if (newAnswer == null) {
+            return null;
+        }
+
+        NarrativeAnswer previousAnswer = previousNarrativeAnswersByQuestionId.get(question.getId());
+        NarrativeAnswerManager answerManager = new NarrativeAnswerManager(question, previousAnswer, newAnswer);
+        return answerManager.getValidatedAnswers();
+    }
+
+    public List<SelectiveAnswer> writeSelectiveAnswers(List<SelectiveAnswer> newSelectiveAnswers) {
+        Map<Long, List<SelectiveAnswer>> newSelectiveAnswersByQuestionId = newSelectiveAnswers.stream()
+                .collect(groupingBy(SelectiveAnswer::getQuestionId));
+
+        return selectiveQuestions.stream()
+                .map(question -> writeSelectiveAnswers(question, newSelectiveAnswersByQuestionId.get(question.getId())))
+                .filter(Objects::nonNull)
+                .flatMap(Collection::stream)
+                .toList();
+    }
+
+    private List<SelectiveAnswer> writeSelectiveAnswers(SelectiveQuestion question,
+                                                        List<SelectiveAnswer> newAnswers) {
+        if (newAnswers == null) {
+            return null;
+        }
+
+        List<SelectiveAnswer> previousAnswers = previousSelectiveAnswersByQuestionId.getOrDefault(question.getId(),
+                List.of());
+        SelectiveAnswerManager answerManager = new SelectiveAnswerManager(question, previousAnswers, newAnswers);
+        return answerManager.getValidatedAnswers();
+    }
+}

--- a/src/main/java/com/server/crews/applicant/application/ApplicationService.java
+++ b/src/main/java/com/server/crews/applicant/application/ApplicationService.java
@@ -1,11 +1,8 @@
 package com.server.crews.applicant.application;
 
-import static java.util.stream.Collectors.toSet;
-
 import com.server.crews.applicant.domain.Application;
 import com.server.crews.applicant.domain.NarrativeAnswer;
 import com.server.crews.applicant.domain.SelectiveAnswer;
-import com.server.crews.applicant.dto.request.AnswerSaveRequest;
 import com.server.crews.applicant.dto.request.ApplicationSaveRequest;
 import com.server.crews.applicant.dto.request.EvaluationRequest;
 import com.server.crews.applicant.dto.response.ApplicationDetailsResponse;
@@ -15,16 +12,12 @@ import com.server.crews.applicant.repository.NarrativeAnswerRepository;
 import com.server.crews.applicant.repository.SelectiveAnswerRepository;
 import com.server.crews.applicant.util.ApplicationMapper;
 import com.server.crews.auth.domain.Applicant;
-import com.server.crews.auth.repository.ApplicantRepository;
 import com.server.crews.global.exception.CrewsErrorCode;
 import com.server.crews.global.exception.CrewsException;
 import com.server.crews.global.exception.NotFoundException;
-import com.server.crews.recruitment.domain.Choice;
 import com.server.crews.recruitment.domain.NarrativeQuestion;
 import com.server.crews.recruitment.domain.Recruitment;
 import com.server.crews.recruitment.domain.SelectiveQuestion;
-import com.server.crews.recruitment.dto.request.QuestionType;
-import com.server.crews.recruitment.repository.ChoiceRepository;
 import com.server.crews.recruitment.repository.NarrativeQuestionRepository;
 import com.server.crews.recruitment.repository.RecruitmentRepository;
 import com.server.crews.recruitment.repository.SelectiveQuestionRepository;
@@ -43,10 +36,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class ApplicationService {
     private final RecruitmentRepository recruitmentRepository;
     private final ApplicationRepository applicationRepository;
-    private final ApplicantRepository applicantRepository;
     private final SelectiveQuestionRepository selectiveQuestionRepository;
     private final NarrativeQuestionRepository narrativeQuestionRepository;
-    private final ChoiceRepository choiceRepository;
     private final SelectiveAnswerRepository selectiveAnswerRepository;
     private final NarrativeAnswerRepository narrativeAnswerRepository;
 
@@ -54,64 +45,34 @@ public class ApplicationService {
     public ApplicationDetailsResponse saveApplication(Long applicantId, ApplicationSaveRequest request) {
         Recruitment recruitment = recruitmentRepository.findByCode(request.recruitmentCode())
                 .orElseThrow(() -> new NotFoundException("모집 공고 코드", "모집 공고"));
+        validateRecruitmentProgress(recruitment);
+
+        Long recruitmentId = recruitment.getId();
+        List<NarrativeQuestion> narrativeQuestions = narrativeQuestionRepository.findAllByRecruitmentId(recruitmentId);
+        List<SelectiveQuestion> selectiveQuestions = selectiveQuestionRepository.findAllByRecruitmentId(recruitmentId);
+        ApplicationForm applicationForm = applicationRepository.findByApplicantId(applicantId)
+                .map(previosApplication ->
+                        new ApplicationForm(narrativeQuestions, selectiveQuestions, previosApplication))
+                .orElse(new ApplicationForm(narrativeQuestions, selectiveQuestions));
+
+        List<NarrativeAnswer> newNarrativeAnswers = ApplicationMapper.narrativeAnswersInApplicationSaveRequest(request);
+        List<SelectiveAnswer> newSelectiveAnswers = ApplicationMapper.selectiveAnswersInApplicationSaveRequest(request);
+
+        List<NarrativeAnswer> updatedNarrativeAnswers = applicationForm.writeNarrativeAnswers(newNarrativeAnswers);
+        List<SelectiveAnswer> updatedSelectiveAnswers = applicationForm.writeSelectiveAnswers(newSelectiveAnswers);
+
+        Application application = ApplicationMapper.applicationSaveRequestToApplication(request, recruitment,
+                new Applicant(applicantId), updatedNarrativeAnswers, updatedSelectiveAnswers);
+        Application savedApplication = applicationRepository.save(application);
+        return ApplicationMapper.applicationToApplicationDetailsResponse(savedApplication);
+    }
+
+    private void validateRecruitmentProgress(Recruitment recruitment) {
         if (!recruitment.isStarted()) {
             throw new CrewsException(CrewsErrorCode.RECRUITMENT_NOT_STARTED);
         }
         if (!recruitment.isInProgress()) {
             throw new CrewsException(CrewsErrorCode.RECRUITMENT_CLOSED);
-        }
-        Applicant applicant = applicantRepository.findById(applicantId)
-                .orElseThrow(() -> new CrewsException(CrewsErrorCode.USER_NOT_FOUND));
-
-        validateNarrativeQuestions(request);
-        validateSelectiveQuestions(request);
-
-        Application application = ApplicationMapper.applicationSaveRequestToApplication(request, recruitment,
-                applicant);
-        Application savedApplication = applicationRepository.save(application);
-        return ApplicationMapper.applicationToApplicationDetailsResponse(savedApplication);
-    }
-
-    private void validateNarrativeQuestions(ApplicationSaveRequest request) {
-        List<AnswerSaveRequest> narrativeAnswerSaveRequests = filterByQuestionType(QuestionType.NARRATIVE, request);
-        Set<Long> narrativeQuestionIds = extractQuestionIds(narrativeAnswerSaveRequests);
-        List<NarrativeQuestion> savedNarrativeQuestions = narrativeQuestionRepository.findAllByIdIn(
-                narrativeQuestionIds);
-        validateQuestionIds(savedNarrativeQuestions, narrativeQuestionIds);
-    }
-
-    private void validateSelectiveQuestions(ApplicationSaveRequest request) {
-        List<AnswerSaveRequest> selectiveAnswerSaveRequests = filterByQuestionType(QuestionType.SELECTIVE, request);
-        Set<Long> selectiveQuestionIds = extractQuestionIds(selectiveAnswerSaveRequests);
-        List<SelectiveQuestion> savedSelectiveQuestions = selectiveQuestionRepository.findAllByIdIn(
-                selectiveQuestionIds);
-        validateQuestionIds(savedSelectiveQuestions, selectiveQuestionIds);
-
-        Set<Long> choiceIds = selectiveAnswerSaveRequests.stream()
-                .map(AnswerSaveRequest::choiceId)
-                .collect(toSet());
-        List<Choice> savedChoices = choiceRepository.findAllByIdIn(choiceIds);
-        if (savedChoices.size() != choiceIds.size()) {
-            throw new NotFoundException("선택지 id", "선택지");
-        }
-    }
-
-    private List<AnswerSaveRequest> filterByQuestionType(QuestionType questionType,
-                                                         ApplicationSaveRequest applicationSaveRequest) {
-        return applicationSaveRequest.answers().stream()
-                .filter(answerSaveRequest -> questionType.hasSameName(answerSaveRequest.questionType()))
-                .toList();
-    }
-
-    private Set<Long> extractQuestionIds(List<AnswerSaveRequest> answerSaveRequests) {
-        return answerSaveRequests.stream()
-                .map(AnswerSaveRequest::questionId)
-                .collect(toSet());
-    }
-
-    private void validateQuestionIds(List<?> savedQuestions, Set<Long> questionIds) {
-        if (savedQuestions.size() != questionIds.size()) {
-            throw new NotFoundException("질문 id", "질문");
         }
     }
 

--- a/src/main/java/com/server/crews/applicant/application/ApplicationService.java
+++ b/src/main/java/com/server/crews/applicant/application/ApplicationService.java
@@ -11,7 +11,6 @@ import com.server.crews.applicant.repository.ApplicationRepository;
 import com.server.crews.applicant.repository.NarrativeAnswerRepository;
 import com.server.crews.applicant.repository.SelectiveAnswerRepository;
 import com.server.crews.applicant.util.ApplicationMapper;
-import com.server.crews.auth.domain.Applicant;
 import com.server.crews.global.exception.CrewsErrorCode;
 import com.server.crews.global.exception.CrewsException;
 import com.server.crews.global.exception.NotFoundException;
@@ -62,7 +61,7 @@ public class ApplicationService {
         List<SelectiveAnswer> updatedSelectiveAnswers = applicationForm.writeSelectiveAnswers(newSelectiveAnswers);
 
         Application application = ApplicationMapper.applicationSaveRequestToApplication(request, recruitment,
-                new Applicant(applicantId), updatedNarrativeAnswers, updatedSelectiveAnswers);
+                applicantId, updatedNarrativeAnswers, updatedSelectiveAnswers);
         Application savedApplication = applicationRepository.save(application);
         return ApplicationMapper.applicationToApplicationDetailsResponse(savedApplication);
     }

--- a/src/main/java/com/server/crews/applicant/application/NarrativeAnswerManager.java
+++ b/src/main/java/com/server/crews/applicant/application/NarrativeAnswerManager.java
@@ -1,0 +1,24 @@
+package com.server.crews.applicant.application;
+
+import com.server.crews.applicant.domain.NarrativeAnswer;
+import com.server.crews.recruitment.domain.NarrativeQuestion;
+
+public class NarrativeAnswerManager extends AnswerManager<NarrativeQuestion, NarrativeAnswer> {
+    public NarrativeAnswerManager(NarrativeQuestion question, NarrativeAnswer previousAnswer,
+                                  NarrativeAnswer newAnswer) {
+        super(question, previousAnswer, newAnswer);
+    }
+
+    @Override
+    protected void validate() {
+        // question 에 따라 검증
+    }
+
+    @Override
+    protected NarrativeAnswer synchronizeWithPreviousAnswers() {
+        if (previousAnswer != null) {
+            newAnswer.setToOriginalId(previousAnswer.getId());
+        }
+        return newAnswer;
+    }
+}

--- a/src/main/java/com/server/crews/applicant/application/SelectiveAnswerManager.java
+++ b/src/main/java/com/server/crews/applicant/application/SelectiveAnswerManager.java
@@ -1,0 +1,29 @@
+package com.server.crews.applicant.application;
+
+import static java.util.stream.Collectors.toMap;
+
+import com.server.crews.applicant.domain.SelectiveAnswer;
+import com.server.crews.recruitment.domain.SelectiveQuestion;
+import java.util.List;
+import java.util.Map;
+
+public class SelectiveAnswerManager extends AnswerManager<SelectiveQuestion, List<SelectiveAnswer>> {
+    public SelectiveAnswerManager(SelectiveQuestion question, List<SelectiveAnswer> previousAnswers,
+                                  List<SelectiveAnswer> updatingAnswers) {
+        super(question, previousAnswers, updatingAnswers);
+    }
+
+    @Override
+    protected void validate() {
+        // question 에 따라 검증
+    }
+
+    @Override
+    protected List<SelectiveAnswer> synchronizeWithPreviousAnswers() {
+        Map<Long, Long> previousAnswerIdsByChoiceId = previousAnswer.stream()
+                .collect(toMap(SelectiveAnswer::getChoiceId, SelectiveAnswer::getId));
+        newAnswer.forEach(selectiveAnswer ->
+                selectiveAnswer.setOriginalId(previousAnswerIdsByChoiceId.get(selectiveAnswer.getChoiceId())));
+        return newAnswer;
+    }
+}

--- a/src/main/java/com/server/crews/applicant/domain/Application.java
+++ b/src/main/java/com/server/crews/applicant/domain/Application.java
@@ -1,5 +1,9 @@
 package com.server.crews.applicant.domain;
 
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toMap;
+
 import com.server.crews.auth.domain.Applicant;
 import com.server.crews.recruitment.domain.Recruitment;
 import jakarta.persistence.CascadeType;
@@ -16,8 +20,10 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -54,10 +60,10 @@ public class Application {
     private String name;
 
     @OneToMany(mappedBy = "application", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<NarrativeAnswer> narrativeAnswers;
+    private Set<NarrativeAnswer> narrativeAnswers;
 
     @OneToMany(mappedBy = "application", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<SelectiveAnswer> selectiveAnswers;
+    private Set<SelectiveAnswer> selectiveAnswers;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(nullable = false, name = "recruitment_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
@@ -84,12 +90,22 @@ public class Application {
 
     public void replaceNarrativeAnswers(List<NarrativeAnswer> narrativeAnswers) {
         narrativeAnswers.forEach(narrativeAnswer -> narrativeAnswer.updateApplication(this));
-        this.narrativeAnswers = new ArrayList<>(narrativeAnswers);
+        this.narrativeAnswers = new HashSet<>(narrativeAnswers);
     }
 
     public void replaceSelectiveAnswers(List<SelectiveAnswer> selectiveAnswers) {
         selectiveAnswers.forEach(selectiveAnswer -> selectiveAnswer.updateApplication(this));
-        this.selectiveAnswers = new ArrayList<>(selectiveAnswers);
+        this.selectiveAnswers = new HashSet<>(selectiveAnswers);
+    }
+
+    public Map<Long, NarrativeAnswer> getNarrativeAnswersByQuestionId() {
+        return this.narrativeAnswers.stream()
+                .collect(toMap(NarrativeAnswer::getQuestionId, identity()));
+    }
+
+    public Map<Long, List<SelectiveAnswer>> getSelectiveAnswersByQuestionId() {
+        return this.selectiveAnswers.stream()
+                .collect(groupingBy(SelectiveAnswer::getQuestionId));
     }
 
     public void pass() {

--- a/src/main/java/com/server/crews/applicant/domain/Application.java
+++ b/src/main/java/com/server/crews/applicant/domain/Application.java
@@ -71,7 +71,7 @@ public class Application {
 
     public Application(Long id,
                        Recruitment recruitment,
-                       Applicant applicant,
+                       Long applicantId,
                        String studentNumber,
                        String major,
                        String name,
@@ -79,7 +79,7 @@ public class Application {
                        List<SelectiveAnswer> selectiveAnswers) {
         this.id = id;
         this.recruitment = recruitment;
-        this.applicant = applicant;
+        this.applicant = new Applicant(applicantId);
         this.studentNumber = studentNumber;
         this.major = major;
         this.name = name;

--- a/src/main/java/com/server/crews/applicant/domain/NarrativeAnswer.java
+++ b/src/main/java/com/server/crews/applicant/domain/NarrativeAnswer.java
@@ -48,4 +48,12 @@ public class NarrativeAnswer {
     public void updateApplication(Application application) {
         this.application = application;
     }
+
+    public void setToOriginalId(Long id) {
+        this.id = id;
+    }
+
+    public Long getQuestionId() {
+        return this.narrativeQuestion.getId();
+    }
 }

--- a/src/main/java/com/server/crews/applicant/domain/NarrativeAnswer.java
+++ b/src/main/java/com/server/crews/applicant/domain/NarrativeAnswer.java
@@ -39,6 +39,11 @@ public class NarrativeAnswer {
     @Column(name = "content", nullable = false, length = 1500)
     private String content;
 
+    public NarrativeAnswer(NarrativeQuestion narrativeQuestion, String content) {
+        this.narrativeQuestion = narrativeQuestion;
+        this.content = content;
+    }
+
     public NarrativeAnswer(Long id, NarrativeQuestion narrativeQuestion, String content) {
         this.id = id;
         this.narrativeQuestion = narrativeQuestion;

--- a/src/main/java/com/server/crews/applicant/domain/SelectiveAnswer.java
+++ b/src/main/java/com/server/crews/applicant/domain/SelectiveAnswer.java
@@ -38,6 +38,11 @@ public class SelectiveAnswer {
     @ManyToOne(fetch = FetchType.LAZY)
     private SelectiveQuestion selectiveQuestion;
 
+    public SelectiveAnswer(Choice choice, SelectiveQuestion selectiveQuestion) {
+        this.choice = choice;
+        this.selectiveQuestion = selectiveQuestion;
+    }
+
     public SelectiveAnswer(Long id, Choice choice, SelectiveQuestion selectiveQuestion) {
         this.id = id;
         this.choice = choice;

--- a/src/main/java/com/server/crews/applicant/domain/SelectiveAnswer.java
+++ b/src/main/java/com/server/crews/applicant/domain/SelectiveAnswer.java
@@ -47,4 +47,16 @@ public class SelectiveAnswer {
     public void updateApplication(Application application) {
         this.application = application;
     }
+
+    public void setOriginalId(Long id) {
+        this.id = id;
+    }
+
+    public Long getQuestionId() {
+        return this.selectiveQuestion.getId();
+    }
+
+    public Long getChoiceId() {
+        return this.choice.getId();
+    }
 }

--- a/src/main/java/com/server/crews/applicant/dto/request/AnswerSaveRequest.java
+++ b/src/main/java/com/server/crews/applicant/dto/request/AnswerSaveRequest.java
@@ -3,15 +3,15 @@ package com.server.crews.applicant.dto.request;
 import com.server.crews.recruitment.presentation.QuestionTypeFormat;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 
 public record AnswerSaveRequest(
-        Long answerId,
+        @NotNull(message = "질문 id는 null일 수 없습니다.")
+        Long questionId,
         @NotBlank(message = "질문 타입은 공백일 수 없습니다.")
         @QuestionTypeFormat
         String questionType,
-        @NotNull(message = "질문 id는 null일 수 없습니다.")
-        Long questionId,
-        String content,
-        Long choiceId
+        List<Long> choiceIds,
+        String content
 ) {
 }

--- a/src/main/java/com/server/crews/applicant/dto/request/ApplicationSaveRequest.java
+++ b/src/main/java/com/server/crews/applicant/dto/request/ApplicationSaveRequest.java
@@ -1,6 +1,8 @@
 package com.server.crews.applicant.dto.request;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public record ApplicationSaveRequest(
@@ -11,7 +13,9 @@ public record ApplicationSaveRequest(
         String major,
         @NotBlank(message = "이름은 공백일 수 없습니다.")
         String name,
-        List<AnswerSaveRequest> answers,
+        @Valid
+        @NotNull(message = "섹션 답변 리스트는 null일 수 없습니다.")
+        List<SectionSaveRequest> sections,
         @NotBlank(message = "모집 공고 코드는 공백일 수 없습니다.")
         String recruitmentCode
 ) {

--- a/src/main/java/com/server/crews/applicant/dto/request/ApplicationSaveRequest.java
+++ b/src/main/java/com/server/crews/applicant/dto/request/ApplicationSaveRequest.java
@@ -15,7 +15,7 @@ public record ApplicationSaveRequest(
         String name,
         @Valid
         @NotNull(message = "섹션 답변 리스트는 null일 수 없습니다.")
-        List<SectionSaveRequest> sections,
+        List<ApplicationSectionSaveRequest> sections,
         @NotBlank(message = "모집 공고 코드는 공백일 수 없습니다.")
         String recruitmentCode
 ) {

--- a/src/main/java/com/server/crews/applicant/dto/request/ApplicationSectionSaveRequest.java
+++ b/src/main/java/com/server/crews/applicant/dto/request/ApplicationSectionSaveRequest.java
@@ -4,7 +4,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
-public record SectionSaveRequest(
+public record ApplicationSectionSaveRequest(
         @NotNull(message = "섹션 id는 null일 수 없습니다.")
         Long sectionId,
         @Valid

--- a/src/main/java/com/server/crews/applicant/dto/request/SectionSaveRequest.java
+++ b/src/main/java/com/server/crews/applicant/dto/request/SectionSaveRequest.java
@@ -1,0 +1,14 @@
+package com.server.crews.applicant.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record SectionSaveRequest(
+        @NotNull(message = "섹션 id는 null일 수 없습니다.")
+        Long sectionId,
+        @Valid
+        @NotNull(message = "답변 리스트는 null일 수 없습니다.")
+        List<AnswerSaveRequest> answers
+) {
+}

--- a/src/main/java/com/server/crews/applicant/dto/response/AnswerResponse.java
+++ b/src/main/java/com/server/crews/applicant/dto/response/AnswerResponse.java
@@ -1,14 +1,14 @@
 package com.server.crews.applicant.dto.response;
 
-import com.server.crews.recruitment.dto.request.QuestionType;
+import com.server.crews.recruitment.domain.QuestionType;
+import java.util.List;
 import lombok.Builder;
 
 @Builder
 public record AnswerResponse(
-        Long answerId,
         Long questionId,
         String content,
-        Long choiceId,
+        List<Long> choiceIds,
         QuestionType type
 ) {
 }

--- a/src/main/java/com/server/crews/applicant/dto/response/ApplicationDetailsResponse.java
+++ b/src/main/java/com/server/crews/applicant/dto/response/ApplicationDetailsResponse.java
@@ -9,6 +9,6 @@ public record ApplicationDetailsResponse(
         String studentNumber,
         String major,
         String name,
-        List<AnswerResponse> answers
+        List<SectionAnswerResponse> sections
 ) {
 }

--- a/src/main/java/com/server/crews/applicant/dto/response/SectionAnswerResponse.java
+++ b/src/main/java/com/server/crews/applicant/dto/response/SectionAnswerResponse.java
@@ -1,0 +1,9 @@
+package com.server.crews.applicant.dto.response;
+
+import java.util.List;
+
+public record SectionAnswerResponse(
+        Long sectionId,
+        List<AnswerResponse> answers
+) {
+}

--- a/src/main/java/com/server/crews/applicant/repository/ApplicationRepository.java
+++ b/src/main/java/com/server/crews/applicant/repository/ApplicationRepository.java
@@ -4,6 +4,7 @@ import com.server.crews.applicant.domain.Application;
 import com.server.crews.recruitment.domain.Recruitment;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -45,4 +46,11 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
             where r.publisher.id = :publisherId
             """)
     List<Application> findAllWithRecruitmentByPublisherId(@Param("publisherId") Long publisherId);
+
+    @EntityGraph(attributePaths = {"narrativeAnswers", "selectiveAnswers"})
+    @Query("""
+            select a from Application a
+            where a.applicant.id = :applicantId
+            """)
+    Optional<Application> findByApplicantId(@Param("applicantId") Long applicantId);
 }

--- a/src/main/java/com/server/crews/applicant/util/AnswerMapper.java
+++ b/src/main/java/com/server/crews/applicant/util/AnswerMapper.java
@@ -7,23 +7,24 @@ import com.server.crews.applicant.dto.response.AnswerResponse;
 import com.server.crews.recruitment.domain.Choice;
 import com.server.crews.recruitment.domain.NarrativeQuestion;
 import com.server.crews.recruitment.domain.SelectiveQuestion;
-import com.server.crews.recruitment.dto.request.QuestionType;
+import com.server.crews.recruitment.domain.QuestionType;
 import java.util.List;
 
 public class AnswerMapper {
 
-    public static AnswerResponse selectiveAnswerToAnswerResponse(SelectiveAnswer selectiveAnswer) {
+    public static AnswerResponse selectiveAnswerToAnswerResponse(List<SelectiveAnswer> selectiveAnswers) {
+        List<Long> choiceIds = selectiveAnswers.stream()
+                .map(SelectiveAnswer::getChoiceId)
+                .toList();
         return AnswerResponse.builder()
-                .answerId(selectiveAnswer.getId())
-                .questionId(selectiveAnswer.getSelectiveQuestion().getId())
-                .choiceId(selectiveAnswer.getChoice().getId())
+                .questionId(selectiveAnswers.get(0).getId())
+                .choiceIds(choiceIds)
                 .type(QuestionType.SELECTIVE)
                 .build();
     }
 
     public static AnswerResponse narrativeAnswerToAnswerResponse(NarrativeAnswer narrativeAnswer) {
         return AnswerResponse.builder()
-                .answerId(narrativeAnswer.getId())
                 .questionId(narrativeAnswer.getNarrativeQuestion().getId())
                 .content(narrativeAnswer.getContent())
                 .type(QuestionType.NARRATIVE)

--- a/src/main/java/com/server/crews/applicant/util/AnswerMapper.java
+++ b/src/main/java/com/server/crews/applicant/util/AnswerMapper.java
@@ -8,7 +8,6 @@ import com.server.crews.recruitment.domain.Choice;
 import com.server.crews.recruitment.domain.NarrativeQuestion;
 import com.server.crews.recruitment.domain.SelectiveQuestion;
 import com.server.crews.recruitment.dto.request.QuestionType;
-import java.util.List;
 
 public class AnswerMapper {
 
@@ -33,13 +32,13 @@ public class AnswerMapper {
     public static SelectiveAnswer answerSaveRequestToSelectiveAnswer(AnswerSaveRequest answerSaveRequest) {
         return new SelectiveAnswer(
                 answerSaveRequest.answerId(),
-                new Choice(answerSaveRequest.choiceId(), null),
-                new SelectiveQuestion(answerSaveRequest.questionId(), List.of(), null, null, null, null, null));
+                new Choice(answerSaveRequest.choiceId()),
+                new SelectiveQuestion(answerSaveRequest.questionId()));
     }
 
     public static NarrativeAnswer answerSaveRequestToNarrativeAnswer(AnswerSaveRequest answerSaveRequest) {
         return new NarrativeAnswer(answerSaveRequest.answerId(),
-                new NarrativeQuestion(answerSaveRequest.questionId(), null, null, null, null),
+                new NarrativeQuestion(answerSaveRequest.questionId()),
                 answerSaveRequest.content());
     }
 }

--- a/src/main/java/com/server/crews/applicant/util/AnswerMapper.java
+++ b/src/main/java/com/server/crews/applicant/util/AnswerMapper.java
@@ -16,8 +16,9 @@ public class AnswerMapper {
         List<Long> choiceIds = selectiveAnswers.stream()
                 .map(SelectiveAnswer::getChoiceId)
                 .toList();
+        Long questionId = selectiveAnswers.get(0).getQuestionId();
         return AnswerResponse.builder()
-                .questionId(selectiveAnswers.get(0).getId())
+                .questionId(questionId)
                 .choiceIds(choiceIds)
                 .type(QuestionType.SELECTIVE)
                 .build();

--- a/src/main/java/com/server/crews/applicant/util/AnswerMapper.java
+++ b/src/main/java/com/server/crews/applicant/util/AnswerMapper.java
@@ -8,6 +8,7 @@ import com.server.crews.recruitment.domain.Choice;
 import com.server.crews.recruitment.domain.NarrativeQuestion;
 import com.server.crews.recruitment.domain.SelectiveQuestion;
 import com.server.crews.recruitment.dto.request.QuestionType;
+import java.util.List;
 
 public class AnswerMapper {
 
@@ -29,16 +30,15 @@ public class AnswerMapper {
                 .build();
     }
 
-    public static SelectiveAnswer answerSaveRequestToSelectiveAnswer(AnswerSaveRequest answerSaveRequest) {
-        return new SelectiveAnswer(
-                answerSaveRequest.answerId(),
-                new Choice(answerSaveRequest.choiceId()),
-                new SelectiveQuestion(answerSaveRequest.questionId()));
+    public static List<SelectiveAnswer> answerSaveRequestToSelectiveAnswer(AnswerSaveRequest answerSaveRequest) {
+        return answerSaveRequest.choiceIds()
+                .stream()
+                .map(choiceId -> new SelectiveAnswer(new Choice(choiceId),
+                        new SelectiveQuestion(answerSaveRequest.questionId())))
+                .toList();
     }
 
     public static NarrativeAnswer answerSaveRequestToNarrativeAnswer(AnswerSaveRequest answerSaveRequest) {
-        return new NarrativeAnswer(answerSaveRequest.answerId(),
-                new NarrativeQuestion(answerSaveRequest.questionId()),
-                answerSaveRequest.content());
+        return new NarrativeAnswer(new NarrativeQuestion(answerSaveRequest.questionId()), answerSaveRequest.content());
     }
 }

--- a/src/main/java/com/server/crews/applicant/util/ApplicationMapper.java
+++ b/src/main/java/com/server/crews/applicant/util/ApplicationMapper.java
@@ -4,7 +4,7 @@ import com.server.crews.applicant.domain.Application;
 import com.server.crews.applicant.domain.NarrativeAnswer;
 import com.server.crews.applicant.domain.SelectiveAnswer;
 import com.server.crews.applicant.dto.request.ApplicationSaveRequest;
-import com.server.crews.applicant.dto.request.SectionSaveRequest;
+import com.server.crews.applicant.dto.request.ApplicationSectionSaveRequest;
 import com.server.crews.applicant.dto.response.AnswerResponse;
 import com.server.crews.applicant.dto.response.ApplicationDetailsResponse;
 import com.server.crews.applicant.dto.response.ApplicationsResponse;
@@ -62,7 +62,7 @@ public class ApplicationMapper {
     public static List<NarrativeAnswer> narrativeAnswersInApplicationSaveRequest(
             ApplicationSaveRequest applicationSaveRequest) {
         return applicationSaveRequest.sections().stream()
-                .map(SectionSaveRequest::answers)
+                .map(ApplicationSectionSaveRequest::answers)
                 .flatMap(Collection::stream)
                 .filter(answerSaveRequest -> QuestionType.NARRATIVE.hasSameName(answerSaveRequest.questionType()))
                 .map(AnswerMapper::answerSaveRequestToNarrativeAnswer)
@@ -72,7 +72,7 @@ public class ApplicationMapper {
     public static List<SelectiveAnswer> selectiveAnswersInApplicationSaveRequest(
             ApplicationSaveRequest applicationSaveRequest) {
         return applicationSaveRequest.sections().stream()
-                .map(SectionSaveRequest::answers)
+                .map(ApplicationSectionSaveRequest::answers)
                 .flatMap(Collection::stream)
                 .filter(answerSaveRequest -> QuestionType.SELECTIVE.hasSameName(answerSaveRequest.questionType()))
                 .map(AnswerMapper::answerSaveRequestToSelectiveAnswer)

--- a/src/main/java/com/server/crews/applicant/util/ApplicationMapper.java
+++ b/src/main/java/com/server/crews/applicant/util/ApplicationMapper.java
@@ -4,13 +4,14 @@ import com.server.crews.applicant.domain.Application;
 import com.server.crews.applicant.domain.NarrativeAnswer;
 import com.server.crews.applicant.domain.SelectiveAnswer;
 import com.server.crews.applicant.dto.request.ApplicationSaveRequest;
+import com.server.crews.applicant.dto.request.SectionSaveRequest;
 import com.server.crews.applicant.dto.response.AnswerResponse;
 import com.server.crews.applicant.dto.response.ApplicationDetailsResponse;
 import com.server.crews.applicant.dto.response.ApplicationsResponse;
-import com.server.crews.auth.domain.Applicant;
 import com.server.crews.recruitment.domain.Recruitment;
 import com.server.crews.recruitment.dto.request.QuestionType;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 public class ApplicationMapper {
@@ -43,24 +44,6 @@ public class ApplicationMapper {
                 .build();
     }
 
-    public static List<NarrativeAnswer> narrativeAnswersInApplicationSaveRequest(
-            ApplicationSaveRequest applicationSaveRequest) {
-        return applicationSaveRequest.answers()
-                .stream()
-                .filter(answerSaveRequest -> QuestionType.NARRATIVE.hasSameName(answerSaveRequest.questionType()))
-                .map(AnswerMapper::answerSaveRequestToNarrativeAnswer)
-                .toList();
-    }
-
-    public static List<SelectiveAnswer> selectiveAnswersInApplicationSaveRequest(
-            ApplicationSaveRequest applicationSaveRequest) {
-        return applicationSaveRequest.answers()
-                .stream()
-                .filter(answerSaveRequest -> QuestionType.SELECTIVE.hasSameName(answerSaveRequest.questionType()))
-                .map(AnswerMapper::answerSaveRequestToSelectiveAnswer)
-                .toList();
-    }
-
     public static Application applicationSaveRequestToApplication(ApplicationSaveRequest applicationSaveRequest,
                                                                   Recruitment recruitment, Long applicantId,
                                                                   List<NarrativeAnswer> narrativeAnswers,
@@ -74,5 +57,26 @@ public class ApplicationMapper {
                 applicationSaveRequest.name(),
                 narrativeAnswers,
                 selectiveAnswers);
+    }
+
+    public static List<NarrativeAnswer> narrativeAnswersInApplicationSaveRequest(
+            ApplicationSaveRequest applicationSaveRequest) {
+        return applicationSaveRequest.sections().stream()
+                .map(SectionSaveRequest::answers)
+                .flatMap(Collection::stream)
+                .filter(answerSaveRequest -> QuestionType.NARRATIVE.hasSameName(answerSaveRequest.questionType()))
+                .map(AnswerMapper::answerSaveRequestToNarrativeAnswer)
+                .toList();
+    }
+
+    public static List<SelectiveAnswer> selectiveAnswersInApplicationSaveRequest(
+            ApplicationSaveRequest applicationSaveRequest) {
+        return applicationSaveRequest.sections().stream()
+                .map(SectionSaveRequest::answers)
+                .flatMap(Collection::stream)
+                .filter(answerSaveRequest -> QuestionType.SELECTIVE.hasSameName(answerSaveRequest.questionType()))
+                .map(AnswerMapper::answerSaveRequestToSelectiveAnswer)
+                .flatMap(Collection::stream)
+                .toList();
     }
 }

--- a/src/main/java/com/server/crews/applicant/util/ApplicationMapper.java
+++ b/src/main/java/com/server/crews/applicant/util/ApplicationMapper.java
@@ -57,6 +57,7 @@ public class ApplicationMapper {
                 .map(ApplicationSectionSaveRequest::answers)
                 .flatMap(Collection::stream)
                 .filter(answerSaveRequest -> QuestionType.NARRATIVE.hasSameName(answerSaveRequest.questionType()))
+                .filter(answerSaveRequest -> answerSaveRequest.content() != null)
                 .map(AnswerMapper::answerSaveRequestToNarrativeAnswer)
                 .toList();
     }
@@ -67,6 +68,7 @@ public class ApplicationMapper {
                 .map(ApplicationSectionSaveRequest::answers)
                 .flatMap(Collection::stream)
                 .filter(answerSaveRequest -> QuestionType.SELECTIVE.hasSameName(answerSaveRequest.questionType()))
+                .filter(answerSaveRequest -> answerSaveRequest.choiceIds() != null)
                 .map(AnswerMapper::answerSaveRequestToSelectiveAnswer)
                 .flatMap(Collection::stream)
                 .toList();

--- a/src/main/java/com/server/crews/applicant/util/ApplicationMapper.java
+++ b/src/main/java/com/server/crews/applicant/util/ApplicationMapper.java
@@ -5,32 +5,24 @@ import com.server.crews.applicant.domain.NarrativeAnswer;
 import com.server.crews.applicant.domain.SelectiveAnswer;
 import com.server.crews.applicant.dto.request.ApplicationSaveRequest;
 import com.server.crews.applicant.dto.request.ApplicationSectionSaveRequest;
-import com.server.crews.applicant.dto.response.AnswerResponse;
 import com.server.crews.applicant.dto.response.ApplicationDetailsResponse;
 import com.server.crews.applicant.dto.response.ApplicationsResponse;
+import com.server.crews.applicant.dto.response.SectionAnswerResponse;
 import com.server.crews.recruitment.domain.Recruitment;
-import com.server.crews.recruitment.dto.request.QuestionType;
-import java.util.ArrayList;
+import com.server.crews.recruitment.domain.QuestionType;
 import java.util.Collection;
 import java.util.List;
 
 public class ApplicationMapper {
 
-    public static ApplicationDetailsResponse applicationToApplicationDetailsResponse(Application application) {
-        List<AnswerResponse> narrativeAnswerResponses = application.getNarrativeAnswers().stream()
-                .map(AnswerMapper::narrativeAnswerToAnswerResponse)
-                .toList();
-        List<AnswerResponse> selectiveAnswerResponses = application.getSelectiveAnswers().stream()
-                .map(AnswerMapper::selectiveAnswerToAnswerResponse)
-                .toList();
-        List<AnswerResponse> allAnswerResponses = new ArrayList<>(narrativeAnswerResponses);
-        allAnswerResponses.addAll(selectiveAnswerResponses);
+    public static ApplicationDetailsResponse applicationToApplicationDetailsResponse(Application application,
+                                                                                     List<SectionAnswerResponse> sectionAnswerResponses) {
         return ApplicationDetailsResponse.builder()
                 .id(application.getId())
                 .studentNumber(application.getStudentNumber())
                 .major(application.getMajor())
                 .name(application.getName())
-                .answers(allAnswerResponses)
+                .sections(sectionAnswerResponses)
                 .build();
     }
 

--- a/src/main/java/com/server/crews/applicant/util/ApplicationMapper.java
+++ b/src/main/java/com/server/crews/applicant/util/ApplicationMapper.java
@@ -3,7 +3,6 @@ package com.server.crews.applicant.util;
 import com.server.crews.applicant.domain.Application;
 import com.server.crews.applicant.domain.NarrativeAnswer;
 import com.server.crews.applicant.domain.SelectiveAnswer;
-import com.server.crews.applicant.dto.request.AnswerSaveRequest;
 import com.server.crews.applicant.dto.request.ApplicationSaveRequest;
 import com.server.crews.applicant.dto.response.AnswerResponse;
 import com.server.crews.applicant.dto.response.ApplicationDetailsResponse;
@@ -44,17 +43,28 @@ public class ApplicationMapper {
                 .build();
     }
 
-    public static Application applicationSaveRequestToApplication(ApplicationSaveRequest applicationSaveRequest,
-                                                                  Recruitment recruitment, Applicant applicant) {
-        List<AnswerSaveRequest> answerSaveRequests = applicationSaveRequest.answers();
-        List<NarrativeAnswer> narrativeAnswers = answerSaveRequests.stream()
+    public static List<NarrativeAnswer> narrativeAnswersInApplicationSaveRequest(
+            ApplicationSaveRequest applicationSaveRequest) {
+        return applicationSaveRequest.answers()
+                .stream()
                 .filter(answerSaveRequest -> QuestionType.NARRATIVE.hasSameName(answerSaveRequest.questionType()))
                 .map(AnswerMapper::answerSaveRequestToNarrativeAnswer)
                 .toList();
-        List<SelectiveAnswer> selectiveAnswers = answerSaveRequests.stream()
+    }
+
+    public static List<SelectiveAnswer> selectiveAnswersInApplicationSaveRequest(
+            ApplicationSaveRequest applicationSaveRequest) {
+        return applicationSaveRequest.answers()
+                .stream()
                 .filter(answerSaveRequest -> QuestionType.SELECTIVE.hasSameName(answerSaveRequest.questionType()))
                 .map(AnswerMapper::answerSaveRequestToSelectiveAnswer)
                 .toList();
+    }
+
+    public static Application applicationSaveRequestToApplication(ApplicationSaveRequest applicationSaveRequest,
+                                                                  Recruitment recruitment, Applicant applicant,
+                                                                  List<NarrativeAnswer> narrativeAnswers,
+                                                                  List<SelectiveAnswer> selectiveAnswers) {
         return new Application(
                 applicationSaveRequest.id(),
                 recruitment,

--- a/src/main/java/com/server/crews/applicant/util/ApplicationMapper.java
+++ b/src/main/java/com/server/crews/applicant/util/ApplicationMapper.java
@@ -62,13 +62,13 @@ public class ApplicationMapper {
     }
 
     public static Application applicationSaveRequestToApplication(ApplicationSaveRequest applicationSaveRequest,
-                                                                  Recruitment recruitment, Applicant applicant,
+                                                                  Recruitment recruitment, Long applicantId,
                                                                   List<NarrativeAnswer> narrativeAnswers,
                                                                   List<SelectiveAnswer> selectiveAnswers) {
         return new Application(
                 applicationSaveRequest.id(),
                 recruitment,
-                applicant,
+                applicantId,
                 applicationSaveRequest.studentNumber(),
                 applicationSaveRequest.major(),
                 applicationSaveRequest.name(),

--- a/src/main/java/com/server/crews/auth/domain/Applicant.java
+++ b/src/main/java/com/server/crews/auth/domain/Applicant.java
@@ -38,6 +38,10 @@ public class Applicant {
         this.password = password;
     }
 
+    public Applicant(Long id) {
+        this.id = id;
+    }
+
     private void validateEmail(String email) {
         if (!Pattern.matches(EMAIL_PATTERN, email)) {
             throw new CrewsException(CrewsErrorCode.INVALID_EMAIL_PATTERN);

--- a/src/main/java/com/server/crews/global/config/DatabaseInitializer.java
+++ b/src/main/java/com/server/crews/global/config/DatabaseInitializer.java
@@ -79,7 +79,7 @@ public class DatabaseInitializer implements ApplicationRunner {
                 "크루즈 프로젝트 서버 개발을 맡았습니다.");
         SelectiveAnswer skhBackendStackAnswer = new SelectiveAnswer(null, backendStackChoices.get(1),
                 backendStackQuestion);
-        Application skhApplication = new Application(null, recruitment, kh, "202011414", "컴퓨터공학", "송경호",
+        Application skhApplication = new Application(null, recruitment, kh.getId(), "202011414", "컴퓨터공학", "송경호",
                 List.of(skhIntroductionAnswer, skhBackendNarrativeAnswer),
                 List.of(skhPersonalityAnswer, skhBackendStackAnswer));
         applicationRepository.save(skhApplication);
@@ -89,7 +89,7 @@ public class DatabaseInitializer implements ApplicationRunner {
                 personalityQuestion);
         NarrativeAnswer lkhFrontendNarrativeAnswer = new NarrativeAnswer(null, frontendNarrativeQuestion,
                 "크루즈 프로젝트 프론트 개발을 맡았습니다.");
-        Application lkhApplication = new Application(null, recruitment, lkh, "202013232", "컴퓨터공학", "이규호",
+        Application lkhApplication = new Application(null, recruitment, lkh.getId(), "202013232", "컴퓨터공학", "이규호",
                 List.of(lkhIntroductionAnswer, lkhFrontendNarrativeAnswer), List.of(lkhPersonalityAnswer));
         applicationRepository.save(lkhApplication);
     }

--- a/src/main/java/com/server/crews/recruitment/domain/Choice.java
+++ b/src/main/java/com/server/crews/recruitment/domain/Choice.java
@@ -33,6 +33,10 @@ public class Choice {
     @Column(name = "content", nullable = false, length = 50)
     private String content;
 
+    public Choice(Long id) {
+        this(id, null);
+    }
+
     public Choice(Long id, String content) {
         this.id = id;
         this.content = content;

--- a/src/main/java/com/server/crews/recruitment/domain/NarrativeQuestion.java
+++ b/src/main/java/com/server/crews/recruitment/domain/NarrativeQuestion.java
@@ -31,7 +31,7 @@ import lombok.NoArgsConstructor;
         }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class NarrativeQuestion {
+public class NarrativeQuestion implements OrderedQuestion {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -77,5 +77,13 @@ public class NarrativeQuestion {
 
     public void updateRecruitment(Recruitment recruitment) {
         this.recruitment = recruitment;
+    }
+
+    public Long getSectionId() {
+        return this.section.getId();
+    }
+
+    public QuestionType getQuestionType() {
+        return QuestionType.NARRATIVE;
     }
 }

--- a/src/main/java/com/server/crews/recruitment/domain/NarrativeQuestion.java
+++ b/src/main/java/com/server/crews/recruitment/domain/NarrativeQuestion.java
@@ -59,6 +59,10 @@ public class NarrativeQuestion {
     @Column(name = "word_limit", nullable = false)
     private Integer wordLimit;
 
+    public NarrativeQuestion(Long id) {
+        this(id, null, null, null, null, null, null);
+    }
+
     public NarrativeQuestion(Long id, String content, Boolean necessity, Integer order, Integer wordLimit) {
         this.id = id;
         this.content = content;

--- a/src/main/java/com/server/crews/recruitment/domain/NarrativeQuestion.java
+++ b/src/main/java/com/server/crews/recruitment/domain/NarrativeQuestion.java
@@ -24,13 +24,21 @@ import lombok.NoArgsConstructor;
 @Entity
 @AllArgsConstructor
 @Table(name = "narrative_question",
-        indexes = @Index(columnList = "section_id", name = "idx_section_id")
+        indexes = {
+                @Index(columnList = "section_id", name = "idx_section_id"),
+                @Index(columnList = "recruitment_id", name = "idx_recruitment_id")
+
+        }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NarrativeQuestion {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recruitment_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Recruitment recruitment;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "section_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
@@ -59,7 +67,11 @@ public class NarrativeQuestion {
         this.wordLimit = wordLimit;
     }
 
-    public void updateSection(final Section section) {
+    public void updateSection(Section section) {
         this.section = section;
+    }
+
+    public void updateRecruitment(Recruitment recruitment) {
+        this.recruitment = recruitment;
     }
 }

--- a/src/main/java/com/server/crews/recruitment/domain/OrderedQuestion.java
+++ b/src/main/java/com/server/crews/recruitment/domain/OrderedQuestion.java
@@ -1,0 +1,16 @@
+package com.server.crews.recruitment.domain;
+
+public interface OrderedQuestion extends Comparable<OrderedQuestion> {
+    Long getId();
+
+    Integer getOrder();
+
+    Long getSectionId();
+
+    QuestionType getQuestionType();
+
+    @Override
+    default int compareTo(OrderedQuestion o) {
+        return Integer.compare(this.getOrder(), o.getOrder());
+    }
+}

--- a/src/main/java/com/server/crews/recruitment/domain/QuestionType.java
+++ b/src/main/java/com/server/crews/recruitment/domain/QuestionType.java
@@ -1,4 +1,4 @@
-package com.server.crews.recruitment.dto.request;
+package com.server.crews.recruitment.domain;
 
 public enum QuestionType {
     NARRATIVE,

--- a/src/main/java/com/server/crews/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/server/crews/recruitment/domain/Recruitment.java
@@ -21,6 +21,7 @@ import jakarta.persistence.Table;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import lombok.AccessLevel;
@@ -97,6 +98,14 @@ public class Recruitment {
 
     public void addSections(List<Section> sections) {
         sections.forEach(section -> section.updateRecruitment(this));
+        sections.stream()
+                .map(section -> section.getSelectiveQuestions())
+                .flatMap(Collection::stream)
+                .forEach(selectiveQuestion -> selectiveQuestion.updateRecruitment(this));
+        sections.stream()
+                .map(section -> section.getNarrativeQuestions())
+                .flatMap(Collection::stream)
+                .forEach(narrativeQuestion -> narrativeQuestion.updateRecruitment(this));
         this.sections.addAll(sections);
     }
 

--- a/src/main/java/com/server/crews/recruitment/domain/SelectiveQuestion.java
+++ b/src/main/java/com/server/crews/recruitment/domain/SelectiveQuestion.java
@@ -1,7 +1,7 @@
 package com.server.crews.recruitment.domain;
 
-import com.server.crews.global.exception.CrewsException;
 import com.server.crews.global.exception.CrewsErrorCode;
+import com.server.crews.global.exception.CrewsException;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
@@ -29,13 +29,20 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(name = "selective_question",
-        indexes = @Index(columnList = "section_id", name = "idx_section_id")
+        indexes = {
+                @Index(columnList = "section_id", name = "idx_section_id"),
+                @Index(columnList = "recruitment_id", name = "idx_recruitment_id")
+        }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SelectiveQuestion {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recruitment_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Recruitment recruitment;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "section_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
@@ -88,7 +95,11 @@ public class SelectiveQuestion {
         }
     }
 
-    public void updateSection(final Section section) {
+    public void updateSection(Section section) {
         this.section = section;
+    }
+
+    public void updateRecruitment(Recruitment recruitment) {
+        this.recruitment = recruitment;
     }
 }

--- a/src/main/java/com/server/crews/recruitment/domain/SelectiveQuestion.java
+++ b/src/main/java/com/server/crews/recruitment/domain/SelectiveQuestion.java
@@ -73,6 +73,10 @@ public class SelectiveQuestion {
     @Column(name = "maximum_selection", nullable = false)
     private Integer maximumSelection;
 
+    public SelectiveQuestion(Long id) {
+        this(id, List.of(), null, null, null, null, null);
+    }
+
     public SelectiveQuestion(Long id, List<Choice> choices, String content, Boolean necessity, Integer order,
                              Integer minimumSelection, Integer maximumSelection) {
         validateSelectionCount(minimumSelection, maximumSelection);

--- a/src/main/java/com/server/crews/recruitment/domain/SelectiveQuestion.java
+++ b/src/main/java/com/server/crews/recruitment/domain/SelectiveQuestion.java
@@ -35,7 +35,7 @@ import lombok.NoArgsConstructor;
         }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class SelectiveQuestion {
+public class SelectiveQuestion implements OrderedQuestion {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -105,5 +105,13 @@ public class SelectiveQuestion {
 
     public void updateRecruitment(Recruitment recruitment) {
         this.recruitment = recruitment;
+    }
+
+    public Long getSectionId() {
+        return this.section.getId();
+    }
+
+    public QuestionType getQuestionType() {
+        return QuestionType.SELECTIVE;
     }
 }

--- a/src/main/java/com/server/crews/recruitment/dto/response/QuestionResponse.java
+++ b/src/main/java/com/server/crews/recruitment/dto/response/QuestionResponse.java
@@ -1,6 +1,6 @@
 package com.server.crews.recruitment.dto.response;
 
-import com.server.crews.recruitment.dto.request.QuestionType;
+import com.server.crews.recruitment.domain.QuestionType;
 import java.util.List;
 import lombok.Builder;
 

--- a/src/main/java/com/server/crews/recruitment/presentation/QuestionTypeFormatValidator.java
+++ b/src/main/java/com/server/crews/recruitment/presentation/QuestionTypeFormatValidator.java
@@ -1,6 +1,6 @@
 package com.server.crews.recruitment.presentation;
 
-import com.server.crews.recruitment.dto.request.QuestionType;
+import com.server.crews.recruitment.domain.QuestionType;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import java.util.Arrays;

--- a/src/main/java/com/server/crews/recruitment/repository/ChoiceRepository.java
+++ b/src/main/java/com/server/crews/recruitment/repository/ChoiceRepository.java
@@ -1,10 +1,7 @@
 package com.server.crews.recruitment.repository;
 
 import com.server.crews.recruitment.domain.Choice;
-import java.util.List;
-import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChoiceRepository extends JpaRepository<Choice, Long> {
-    List<Choice> findAllByIdIn(Set<Long> ids);
 }

--- a/src/main/java/com/server/crews/recruitment/repository/NarrativeQuestionRepository.java
+++ b/src/main/java/com/server/crews/recruitment/repository/NarrativeQuestionRepository.java
@@ -5,9 +5,16 @@ import com.server.crews.recruitment.domain.Section;
 import java.util.List;
 import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface NarrativeQuestionRepository extends JpaRepository<NarrativeQuestion, Long> {
     List<NarrativeQuestion> findAllBySectionIn(List<Section> sections);
 
     List<NarrativeQuestion> findAllByIdIn(Set<Long> questionIds);
+
+    @Query("""
+            select n from NarrativeQuestion n
+            where n.recruitment.id = :recruitmentId
+            """)
+    List<NarrativeQuestion> findAllByRecruitmentId(Long recruitmentId);
 }

--- a/src/main/java/com/server/crews/recruitment/repository/SelectiveQuestionRepository.java
+++ b/src/main/java/com/server/crews/recruitment/repository/SelectiveQuestionRepository.java
@@ -17,4 +17,10 @@ public interface SelectiveQuestionRepository extends JpaRepository<SelectiveQues
             where s.section in :sections
             """)
     List<SelectiveQuestion> findAllWithChoicesInSections(@Param("sections") List<Section> sections);
+
+    @Query("""
+            select s from SelectiveQuestion s
+            where s.recruitment.id = :recruitmentId
+            """)
+    List<SelectiveQuestion> findAllByRecruitmentId(@Param("recruitmentId") Long recruitmentId);
 }

--- a/src/main/java/com/server/crews/recruitment/util/QuestionMapper.java
+++ b/src/main/java/com/server/crews/recruitment/util/QuestionMapper.java
@@ -5,7 +5,7 @@ import com.server.crews.recruitment.domain.NarrativeQuestion;
 import com.server.crews.recruitment.domain.SelectiveQuestion;
 import com.server.crews.recruitment.dto.request.ChoiceSaveRequest;
 import com.server.crews.recruitment.dto.request.QuestionSaveRequest;
-import com.server.crews.recruitment.dto.request.QuestionType;
+import com.server.crews.recruitment.domain.QuestionType;
 import com.server.crews.recruitment.dto.response.ChoiceResponse;
 import com.server.crews.recruitment.dto.response.QuestionResponse;
 import java.util.List;

--- a/src/main/java/com/server/crews/recruitment/util/QuestionSorter.java
+++ b/src/main/java/com/server/crews/recruitment/util/QuestionSorter.java
@@ -1,6 +1,6 @@
 package com.server.crews.recruitment.util;
 
-import com.server.crews.recruitment.dto.request.QuestionType;
+import com.server.crews.recruitment.domain.QuestionType;
 import com.server.crews.recruitment.dto.response.ChoiceResponse;
 import com.server.crews.recruitment.dto.response.QuestionResponse;
 import com.server.crews.recruitment.dto.response.RecruitmentDetailsResponse;

--- a/src/main/java/com/server/crews/recruitment/util/SectionMapper.java
+++ b/src/main/java/com/server/crews/recruitment/util/SectionMapper.java
@@ -4,7 +4,7 @@ import com.server.crews.recruitment.domain.NarrativeQuestion;
 import com.server.crews.recruitment.domain.Section;
 import com.server.crews.recruitment.domain.SelectiveQuestion;
 import com.server.crews.recruitment.dto.request.QuestionSaveRequest;
-import com.server.crews.recruitment.dto.request.QuestionType;
+import com.server.crews.recruitment.domain.QuestionType;
 import com.server.crews.recruitment.dto.request.SectionSaveRequest;
 import com.server.crews.recruitment.dto.response.QuestionResponse;
 import com.server.crews.recruitment.dto.response.SectionResponse;

--- a/src/test/java/com/server/crews/api/ApiTest.java
+++ b/src/test/java/com/server/crews/api/ApiTest.java
@@ -10,6 +10,7 @@ import static org.springframework.restdocs.restassured.RestAssuredRestDocumentat
 
 import com.server.crews.applicant.dto.request.AnswerSaveRequest;
 import com.server.crews.applicant.dto.request.ApplicationSaveRequest;
+import com.server.crews.applicant.dto.request.SectionSaveRequest;
 import com.server.crews.applicant.dto.response.ApplicationDetailsResponse;
 import com.server.crews.auth.dto.request.AdminLoginRequest;
 import com.server.crews.auth.dto.request.ApplicantLoginRequest;
@@ -70,13 +71,12 @@ public abstract class ApiTest {
         databaseCleaner.clear();
     }
 
-    protected ApplicationSaveRequest applicationSaveRequest(String recruitmentCode) {
+    protected ApplicationSaveRequest applicationSaveRequest(String recruitmentCode, Long sectionId) {
         List<AnswerSaveRequest> answerSaveRequests = List.of(
-                new AnswerSaveRequest(null, QuestionType.NARRATIVE.name(), 2L, DEFAULT_NARRATIVE_ANSWER, null),
-                new AnswerSaveRequest(null, QuestionType.SELECTIVE.name(), 1L, null, 1L),
-                new AnswerSaveRequest(null, QuestionType.SELECTIVE.name(), 1L, null, 2L));
+                new AnswerSaveRequest(2l, QuestionType.NARRATIVE.name(), null, DEFAULT_NARRATIVE_ANSWER),
+                new AnswerSaveRequest(1l, QuestionType.SELECTIVE.name(), List.of(1l, 2l), null));
         return new ApplicationSaveRequest(null, DEFAULT_STUDENT_NUMBER, DEFAULT_MAJOR, DEFAULT_NAME,
-                answerSaveRequests, recruitmentCode);
+                List.of(new SectionSaveRequest(sectionId, answerSaveRequests)), recruitmentCode);
     }
 
     protected TokenResponse signUpAdmin(String clubName, String password) {

--- a/src/test/java/com/server/crews/api/ApiTest.java
+++ b/src/test/java/com/server/crews/api/ApiTest.java
@@ -20,7 +20,7 @@ import com.server.crews.environ.DatabaseCleaner;
 import com.server.crews.external.application.EmailService;
 import com.server.crews.global.config.DatabaseInitializer;
 import com.server.crews.recruitment.domain.Recruitment;
-import com.server.crews.recruitment.dto.request.QuestionType;
+import com.server.crews.recruitment.domain.QuestionType;
 import com.server.crews.recruitment.dto.request.RecruitmentSaveRequest;
 import com.server.crews.recruitment.dto.response.RecruitmentDetailsResponse;
 import com.server.crews.recruitment.repository.RecruitmentRepository;

--- a/src/test/java/com/server/crews/api/ApiTest.java
+++ b/src/test/java/com/server/crews/api/ApiTest.java
@@ -10,7 +10,7 @@ import static org.springframework.restdocs.restassured.RestAssuredRestDocumentat
 
 import com.server.crews.applicant.dto.request.AnswerSaveRequest;
 import com.server.crews.applicant.dto.request.ApplicationSaveRequest;
-import com.server.crews.applicant.dto.request.SectionSaveRequest;
+import com.server.crews.applicant.dto.request.ApplicationSectionSaveRequest;
 import com.server.crews.applicant.dto.response.ApplicationDetailsResponse;
 import com.server.crews.auth.dto.request.AdminLoginRequest;
 import com.server.crews.auth.dto.request.ApplicantLoginRequest;
@@ -76,7 +76,7 @@ public abstract class ApiTest {
                 new AnswerSaveRequest(2l, QuestionType.NARRATIVE.name(), null, DEFAULT_NARRATIVE_ANSWER),
                 new AnswerSaveRequest(1l, QuestionType.SELECTIVE.name(), List.of(1l, 2l), null));
         return new ApplicationSaveRequest(null, DEFAULT_STUDENT_NUMBER, DEFAULT_MAJOR, DEFAULT_NAME,
-                List.of(new SectionSaveRequest(sectionId, answerSaveRequests)), recruitmentCode);
+                List.of(new ApplicationSectionSaveRequest(sectionId, answerSaveRequests)), recruitmentCode);
     }
 
     protected TokenResponse signUpAdmin(String clubName, String password) {

--- a/src/test/java/com/server/crews/api/ApplicationApiDocuments.java
+++ b/src/test/java/com/server/crews/api/ApplicationApiDocuments.java
@@ -23,12 +23,13 @@ public class ApplicationApiDocuments {
                         fieldWithPath(".studentNumber").description("학번"),
                         fieldWithPath(".major").description("전공"),
                         fieldWithPath(".name").description("지원자 이름"),
-                        fieldWithPath(".answers").description("답변 목록"),
-                        fieldWithPath(".answers[].answerId").description("답변 id").optional(),
-                        fieldWithPath(".answers[].questionType").description("질문 타입(NARRATIVE, SELECTIVE 중 하나)"),
-                        fieldWithPath(".answers[].questionId").description("질문 id"),
-                        fieldWithPath(".answers[].content").description("서술형 답안 (NARRATIVE 질문의 경우)").optional(),
-                        fieldWithPath(".answers[].choiceId").description("선택지 id (SELECTIVE 질문의 경우)").optional()),
+                        fieldWithPath(".sections").description("섹션 목록"),
+                        fieldWithPath(".sections[].sectionId").description("섹션 id"),
+                        fieldWithPath(".sections[].answers[]").description("섹션의 답안 목록"),
+                        fieldWithPath(".sections[].answers[].questionType").description("질문 타입(NARRATIVE, SELECTIVE 중 하나)"),
+                        fieldWithPath(".sections[].answers[].questionId").description("질문 id"),
+                        fieldWithPath(".sections[].answers[].content").description("서술형 답안 (NARRATIVE 질문의 경우)").optional(),
+                        fieldWithPath(".sections[].answers[].choiceIds").description("선택지 id 목록 (SELECTIVE 질문의 경우)").optional()),
                 applicationDetailsResponseFields());
     }
 

--- a/src/test/java/com/server/crews/api/ApplicationApiDocuments.java
+++ b/src/test/java/com/server/crews/api/ApplicationApiDocuments.java
@@ -92,11 +92,12 @@ public class ApplicationApiDocuments {
                 fieldWithPath(".studentNumber").description("학번"),
                 fieldWithPath(".major").description("전공"),
                 fieldWithPath(".name").description("지원자 이름"),
-                fieldWithPath(".answers").description("답변 목록"),
-                fieldWithPath(".answers[].answerId").description("답변 id"),
-                fieldWithPath(".answers[].type").description("답변 타입(NARRATIVE, SELECTIVE 중 하나)"),
-                fieldWithPath(".answers[].choiceId").description("선택지 id (SELECTIVE 질문의 경우)").optional(),
-                fieldWithPath(".answers[].content").description("서술형 답안 (NARRATIVE 질문의 경우)").optional(),
-                fieldWithPath(".answers[].questionId").description("질문 id"));
+                fieldWithPath(".sections").description("섹션 목록"),
+                fieldWithPath(".sections[].sectionId").description("섹션 id"),
+                fieldWithPath(".sections[].answers").description("답변 목록"),
+                fieldWithPath(".sections[].answers[].type").description("답변 타입(NARRATIVE, SELECTIVE 중 하나)"),
+                fieldWithPath(".sections[].answers[].choiceIds").description("선택지 id 리스트 (SELECTIVE 질문의 경우)").optional(),
+                fieldWithPath(".sections[].answers[].content").description("서술형 답안 (NARRATIVE 질문의 경우)").optional(),
+                fieldWithPath(".sections[].answers[].questionId").description("질문 id"));
     }
 }

--- a/src/test/java/com/server/crews/api/ApplicationApiTest.java
+++ b/src/test/java/com/server/crews/api/ApplicationApiTest.java
@@ -91,11 +91,12 @@ public class ApplicationApiTest extends ApiTest {
             softAssertions.assertThat(applicationDetailsResponse.id()).isNotNull();
             softAssertions.assertThat(answerResponses)
                     .filteredOn(answerResponse -> answerResponse.type() == QuestionType.NARRATIVE)
-                    .hasSize(1);
+                    .isNotEmpty();
             softAssertions.assertThat(answerResponses)
                     .filteredOn(answerResponse -> answerResponse.type() == QuestionType.SELECTIVE)
+                    .filteredOn(answerResponse -> answerResponse.choiceIds() != null)
                     .flatExtracting(AnswerResponse::choiceIds)
-                    .hasSize(1);
+                    .isNotEmpty();
         });
     }
 
@@ -198,6 +199,7 @@ public class ApplicationApiTest extends ApiTest {
                     .isNotEmpty();
             softAssertions.assertThat(answerResponses)
                     .filteredOn(answerResponse -> answerResponse.type() == QuestionType.SELECTIVE)
+                    .filteredOn(answerResponse -> answerResponse.choiceIds() != null)
                     .flatExtracting(AnswerResponse::choiceIds)
                     .isNotEmpty();
         });
@@ -241,6 +243,7 @@ public class ApplicationApiTest extends ApiTest {
                     .isNotEmpty();
             softAssertions.assertThat(answerResponses)
                     .filteredOn(answerResponse -> answerResponse.type() == QuestionType.SELECTIVE)
+                    .filteredOn(answerResponse -> answerResponse.choiceIds() != null)
                     .flatExtracting(AnswerResponse::choiceIds)
                     .isNotEmpty();
         });

--- a/src/test/java/com/server/crews/api/ApplicationApiTest.java
+++ b/src/test/java/com/server/crews/api/ApplicationApiTest.java
@@ -15,7 +15,7 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import com.server.crews.applicant.dto.request.AnswerSaveRequest;
 import com.server.crews.applicant.dto.request.ApplicationSaveRequest;
 import com.server.crews.applicant.dto.request.EvaluationRequest;
-import com.server.crews.applicant.dto.request.SectionSaveRequest;
+import com.server.crews.applicant.dto.request.ApplicationSectionSaveRequest;
 import com.server.crews.applicant.dto.response.AnswerResponse;
 import com.server.crews.applicant.dto.response.ApplicationDetailsResponse;
 import com.server.crews.applicant.dto.response.ApplicationsResponse;
@@ -48,9 +48,9 @@ public class ApplicationApiTest extends ApiTest {
         List<AnswerSaveRequest> firstAnswerSaveRequests = List.of(
                 new AnswerSaveRequest(2l, QuestionType.NARRATIVE.name(), null, DEFAULT_NARRATIVE_ANSWER),
                 new AnswerSaveRequest(1l, QuestionType.SELECTIVE.name(), List.of(2l), null));
-        SectionSaveRequest firstSectionSaveRequest = new SectionSaveRequest(1l, firstAnswerSaveRequests);
+        ApplicationSectionSaveRequest firstApplicationSectionSaveRequest = new ApplicationSectionSaveRequest(1l, firstAnswerSaveRequests);
         ApplicationSaveRequest applicationCreateRequest = new ApplicationSaveRequest(null, DEFAULT_STUDENT_NUMBER,
-                DEFAULT_MAJOR, DEFAULT_NAME, List.of(firstSectionSaveRequest), recruitmentDetailsResponse.code());
+                DEFAULT_MAJOR, DEFAULT_NAME, List.of(firstApplicationSectionSaveRequest), recruitmentDetailsResponse.code());
         ApplicationDetailsResponse testApplication = createTestApplication(applicantTokenResponse.accessToken(),
                 applicationCreateRequest);
 
@@ -58,9 +58,9 @@ public class ApplicationApiTest extends ApiTest {
                 new AnswerSaveRequest(2l, QuestionType.NARRATIVE.name(), null, "수정된내용"),
                 new AnswerSaveRequest(1l, QuestionType.SELECTIVE.name(), List.of(2l), null));
 
-        SectionSaveRequest secondSectionSaveRequest = new SectionSaveRequest(1l, secondAnswerSaveRequests);
+        ApplicationSectionSaveRequest secondApplicationSectionSaveRequest = new ApplicationSectionSaveRequest(1l, secondAnswerSaveRequests);
         ApplicationSaveRequest applicationUpdateRequest = new ApplicationSaveRequest(testApplication.id(),
-                DEFAULT_STUDENT_NUMBER, DEFAULT_MAJOR, DEFAULT_NAME, List.of(secondSectionSaveRequest),
+                DEFAULT_STUDENT_NUMBER, DEFAULT_MAJOR, DEFAULT_NAME, List.of(secondApplicationSectionSaveRequest),
                 recruitmentDetailsResponse.code());
 
         // when

--- a/src/test/java/com/server/crews/api/RecruitmentApiTest.java
+++ b/src/test/java/com/server/crews/api/RecruitmentApiTest.java
@@ -286,7 +286,7 @@ public class RecruitmentApiTest extends ApiTest {
         TokenResponse applicantATokenResponse = signUpApplicant("A" + TEST_EMAIL, TEST_PASSWORD);
         TokenResponse applicantBTokenResponse = signUpApplicant("B" + TEST_EMAIL, TEST_PASSWORD);
 
-        ApplicationSaveRequest applicationSaveRequest = applicationSaveRequest(recruitmentDetailsResponse.code());
+        ApplicationSaveRequest applicationSaveRequest = applicationSaveRequest(recruitmentDetailsResponse.code(), 1l);
         createTestApplication(applicantATokenResponse.accessToken(), applicationSaveRequest);
         createTestApplication(applicantBTokenResponse.accessToken(), applicationSaveRequest);
 
@@ -518,7 +518,7 @@ public class RecruitmentApiTest extends ApiTest {
         TokenResponse applicantATokenResponse = signUpApplicant("A" + TEST_EMAIL, TEST_PASSWORD);
         TokenResponse applicantBTokenResponse = signUpApplicant("B" + TEST_EMAIL, TEST_PASSWORD);
 
-        ApplicationSaveRequest applicationSaveRequest = applicationSaveRequest(recruitmentDetailsResponse.code());
+        ApplicationSaveRequest applicationSaveRequest = applicationSaveRequest(recruitmentDetailsResponse.code(), 1l);
         createTestApplication(applicantATokenResponse.accessToken(), applicationSaveRequest);
         createTestApplication(applicantBTokenResponse.accessToken(), applicationSaveRequest);
 
@@ -546,7 +546,7 @@ public class RecruitmentApiTest extends ApiTest {
         TokenResponse applicantATokenResponse = signUpApplicant("A" + TEST_EMAIL, TEST_PASSWORD);
         TokenResponse applicantBTokenResponse = signUpApplicant("B" + TEST_EMAIL, TEST_PASSWORD);
 
-        ApplicationSaveRequest applicationSaveRequest = applicationSaveRequest(recruitmentDetailsResponse.code());
+        ApplicationSaveRequest applicationSaveRequest = applicationSaveRequest(recruitmentDetailsResponse.code(), 1l);
         createTestApplication(applicantATokenResponse.accessToken(), applicationSaveRequest);
         createTestApplication(applicantBTokenResponse.accessToken(), applicationSaveRequest);
 

--- a/src/test/java/com/server/crews/api/RecruitmentApiTest.java
+++ b/src/test/java/com/server/crews/api/RecruitmentApiTest.java
@@ -27,7 +27,7 @@ import com.server.crews.recruitment.domain.RecruitmentProgress;
 import com.server.crews.recruitment.dto.request.ChoiceSaveRequest;
 import com.server.crews.recruitment.dto.request.DeadlineUpdateRequest;
 import com.server.crews.recruitment.dto.request.QuestionSaveRequest;
-import com.server.crews.recruitment.dto.request.QuestionType;
+import com.server.crews.recruitment.domain.QuestionType;
 import com.server.crews.recruitment.dto.request.RecruitmentSaveRequest;
 import com.server.crews.recruitment.dto.request.SectionSaveRequest;
 import com.server.crews.recruitment.dto.response.QuestionResponse;

--- a/src/test/java/com/server/crews/applicant/application/ApplicationServiceTest.java
+++ b/src/test/java/com/server/crews/applicant/application/ApplicationServiceTest.java
@@ -94,14 +94,20 @@ class ApplicationServiceTest extends ServiceTest {
     }
 
     private static Stream<Arguments> provideAnswersAndCount() {
-        AnswerSaveRequest narrativeAnswerSaveRequest = new AnswerSaveRequest(2l, QuestionType.NARRATIVE.name(),
+        AnswerSaveRequest narrativeAnswerSaveRequest = new AnswerSaveRequest(1l, QuestionType.NARRATIVE.name(),
                 null, DEFAULT_NARRATIVE_ANSWER);
         AnswerSaveRequest selectiveAnswerSaveRequest = new AnswerSaveRequest(1l, QuestionType.SELECTIVE.name(),
                 List.of(1l, 2l), null);
+        AnswerSaveRequest nullNarrativeAnswerSaveRequest = new AnswerSaveRequest(2l, QuestionType.NARRATIVE.name(),
+                null, null);
+        AnswerSaveRequest nullSelectiveAnswerSaveRequest = new AnswerSaveRequest(2l, QuestionType.SELECTIVE.name(),
+                null, null);
         return Stream.of(
                 Arguments.of(List.of(
                         new ApplicationSectionSaveRequest(1l, List.of(narrativeAnswerSaveRequest)),
-                        new ApplicationSectionSaveRequest(1l, List.of(selectiveAnswerSaveRequest))), 1, 2),
+                        new ApplicationSectionSaveRequest(1l, List.of(selectiveAnswerSaveRequest)),
+                        new ApplicationSectionSaveRequest(2l, List.of(nullNarrativeAnswerSaveRequest)),
+                        new ApplicationSectionSaveRequest(2l, List.of(nullSelectiveAnswerSaveRequest))), 1, 2),
                 Arguments.of(List.of(
                         new ApplicationSectionSaveRequest(1l, List.of(narrativeAnswerSaveRequest))), 1, 0));
     }

--- a/src/test/java/com/server/crews/applicant/application/ApplicationServiceTest.java
+++ b/src/test/java/com/server/crews/applicant/application/ApplicationServiceTest.java
@@ -136,12 +136,13 @@ class ApplicationServiceTest extends ServiceTest {
                 .flatMap(Collection::stream)
                 .toList();
         assertAll(() -> {
-            assertThat(answerResponses).hasSize(2);
-            assertThat(response.sections().get(1).answers()).isEmpty();
+            assertThat(answerResponses).hasSize(4);
             assertThat(answerResponses).filteredOn(answerResponse -> answerResponse.type() == QuestionType.NARRATIVE)
+                    .filteredOn(answerResponse -> answerResponse.content() != null)
                     .extracting(AnswerResponse::content)
-                    .containsExactly("안녕하세요");
+                    .contains("안녕하세요");
             assertThat(answerResponses).filteredOn(answerResponse -> answerResponse.type() == QuestionType.SELECTIVE)
+                    .filteredOn(answerResponse -> answerResponse.choiceIds() != null)
                     .flatExtracting(AnswerResponse::choiceIds)
                     .contains(1L, 2L);
         });

--- a/src/test/java/com/server/crews/applicant/application/ApplicationServiceTest.java
+++ b/src/test/java/com/server/crews/applicant/application/ApplicationServiceTest.java
@@ -33,6 +33,7 @@ import com.server.crews.recruitment.domain.Choice;
 import com.server.crews.recruitment.domain.NarrativeQuestion;
 import com.server.crews.recruitment.domain.QuestionType;
 import com.server.crews.recruitment.domain.Recruitment;
+import com.server.crews.recruitment.domain.Section;
 import com.server.crews.recruitment.domain.SelectiveQuestion;
 import java.util.Collection;
 import java.util.Comparator;
@@ -114,9 +115,10 @@ class ApplicationServiceTest extends ServiceTest {
                 .addSection(BACKEND_SECTION_NAME, List.of(NARRATIVE_QUESTION()), List.of(SELECTIVE_QUESTION()))
                 .addSection(FRONTEND_SECTION_NAME, List.of(NARRATIVE_QUESTION()), List.of(SELECTIVE_QUESTION()));
         Applicant applicant = JONGMEE_APPLICANT().applicant();
-        NarrativeQuestion narrativeQuestion = testRecruitment.narrativeQuestions().get(0);
-        SelectiveQuestion selectiveQuestion = testRecruitment.selectiveQuestions().get(0);
-        List<Choice> choices = testRecruitment.choices(0);
+        List<Section> sections = testRecruitment.sections();
+        NarrativeQuestion narrativeQuestion = sections.get(0).getNarrativeQuestions().get(0);
+        SelectiveQuestion selectiveQuestion = sections.get(0).getSelectiveQuestions().get(0);
+        List<Choice> choices = selectiveQuestion.getChoices();
         Application application = JONGMEE_APPLICATION(applicant, testRecruitment.recruitment())
                 .addNarrativeAnswers(narrativeQuestion, "안녕하세요")
                 .saveSelectiveAnswers(selectiveQuestion, choices.get(0))

--- a/src/test/java/com/server/crews/applicant/application/ApplicationServiceTest.java
+++ b/src/test/java/com/server/crews/applicant/application/ApplicationServiceTest.java
@@ -18,7 +18,7 @@ import com.server.crews.applicant.domain.SelectiveAnswer;
 import com.server.crews.applicant.dto.request.AnswerSaveRequest;
 import com.server.crews.applicant.dto.request.ApplicationSaveRequest;
 import com.server.crews.applicant.dto.request.EvaluationRequest;
-import com.server.crews.applicant.dto.request.SectionSaveRequest;
+import com.server.crews.applicant.dto.request.ApplicationSectionSaveRequest;
 import com.server.crews.applicant.dto.response.AnswerResponse;
 import com.server.crews.applicant.dto.response.ApplicationDetailsResponse;
 import com.server.crews.applicant.repository.ApplicationRepository;
@@ -59,7 +59,7 @@ class ApplicationServiceTest extends ServiceTest {
     @ParameterizedTest
     @MethodSource("provideAnswersAndCount")
     @DisplayName("답변을 작성한 지원서를 저장한다.")
-    void saveApplication(List<SectionSaveRequest> sectionSaveRequests, int expectedSavedNarrativeAnsCount,
+    void saveApplication(List<ApplicationSectionSaveRequest> applicationSectionSaveRequests, int expectedSavedNarrativeAnsCount,
                          int expectedSavedSelectiveAnsCount) {
         // given
         Administrator publisher = LIKE_LION_ADMIN().administrator();
@@ -71,7 +71,7 @@ class ApplicationServiceTest extends ServiceTest {
         Applicant applicant = JONGMEE_APPLICANT().applicant();
 
         ApplicationSaveRequest saveRequest = new ApplicationSaveRequest(null, DEFAULT_STUDENT_NUMBER, DEFAULT_MAJOR,
-                DEFAULT_NAME, sectionSaveRequests, recruitment.getCode());
+                DEFAULT_NAME, applicationSectionSaveRequests, recruitment.getCode());
 
         // when
         ApplicationDetailsResponse applicationDetailsResponse = applicationService.saveApplication(applicant.getId(),
@@ -94,10 +94,10 @@ class ApplicationServiceTest extends ServiceTest {
                 List.of(1l, 2l), null);
         return Stream.of(
                 Arguments.of(List.of(
-                        new SectionSaveRequest(1l, List.of(narrativeAnswerSaveRequest)),
-                        new SectionSaveRequest(2l, List.of(selectiveAnswerSaveRequest))), 1, 2),
+                        new ApplicationSectionSaveRequest(1l, List.of(narrativeAnswerSaveRequest)),
+                        new ApplicationSectionSaveRequest(2l, List.of(selectiveAnswerSaveRequest))), 1, 2),
                 Arguments.of(List.of(
-                        new SectionSaveRequest(1l, List.of(narrativeAnswerSaveRequest))), 1, 0));
+                        new ApplicationSectionSaveRequest(1l, List.of(narrativeAnswerSaveRequest))), 1, 0));
     }
 
     @Test

--- a/src/test/java/com/server/crews/applicant/repository/ApplicationRepositoryTest.java
+++ b/src/test/java/com/server/crews/applicant/repository/ApplicationRepositoryTest.java
@@ -23,7 +23,7 @@ class ApplicationRepositoryTest extends RepositoryTest {
         Administrator admin = createDefaultAdmin();
         Recruitment recruitment = createDefaultRecruitment(admin);
         Applicant applicant = createDefaultApplicant("test@gmail.com");
-        Application application = createDefaultApplication(applicant, recruitment);
+        Application application = createDefaultApplication(applicant.getId(), recruitment);
 
         // when
         List<Application> applications = applicationRepository.findAllWithRecruitmentByPublisherId(admin.getId());
@@ -40,8 +40,8 @@ class ApplicationRepositoryTest extends RepositoryTest {
         Recruitment recruitment = createDefaultRecruitment(admin);
         Applicant firstApplicant = createDefaultApplicant("test1@gmail.com");
         Applicant secondApplicant = createDefaultApplicant("test2@gmail.com");
-        createDefaultApplication(firstApplicant, recruitment);
-        createDefaultApplication(secondApplicant, recruitment);
+        createDefaultApplication(firstApplicant.getId(), recruitment);
+        createDefaultApplication(secondApplicant.getId(), recruitment);
 
         // when
         int applicationCount = applicationRepository.countAllByRecruitment(recruitment);

--- a/src/test/java/com/server/crews/environ/repository/RepositoryTest.java
+++ b/src/test/java/com/server/crews/environ/repository/RepositoryTest.java
@@ -97,8 +97,8 @@ public abstract class RepositoryTest {
         return choices;
     }
 
-    protected Application createDefaultApplication(Applicant applicant, Recruitment recruitment) {
-        Application application = APPLICATION(applicant, recruitment, List.of(), List.of());
+    protected Application createDefaultApplication(Long applicantId, Recruitment recruitment) {
+        Application application = APPLICATION(applicantId, recruitment, List.of(), List.of());
         testRepository.save(application);
         return application;
     }

--- a/src/test/java/com/server/crews/environ/repository/RepositoryTest.java
+++ b/src/test/java/com/server/crews/environ/repository/RepositoryTest.java
@@ -80,12 +80,14 @@ public abstract class RepositoryTest {
     private NarrativeQuestion createNarrativeQuestion(Section section) {
         NarrativeQuestion narrativeQuestion = NARRATIVE_QUESTION();
         narrativeQuestion.updateSection(section);
+        narrativeQuestion.updateRecruitment(section.getRecruitment());
         return narrativeQuestion;
     }
 
     private SelectiveQuestion createSelectiveQuestion(Section section) {
         SelectiveQuestion selectiveQuestion = SELECTIVE_QUESTION();
         selectiveQuestion.updateSection(section);
+        selectiveQuestion.updateRecruitment(section.getRecruitment());
         return selectiveQuestion;
     }
 

--- a/src/test/java/com/server/crews/environ/service/TestApplication.java
+++ b/src/test/java/com/server/crews/environ/service/TestApplication.java
@@ -25,7 +25,7 @@ public class TestApplication {
 
     public TestApplication create(Applicant applicant, Recruitment recruitment, String studentNumber, String major,
                                   String name) {
-        Application application = new Application(null, recruitment, applicant, studentNumber, major, name, List.of(),
+        Application application = new Application(null, recruitment, applicant.getId(), studentNumber, major, name, List.of(),
                 List.of());
         this.application = environ.applicationRepository().save(application);
         return this;

--- a/src/test/java/com/server/crews/environ/service/TestRecruitment.java
+++ b/src/test/java/com/server/crews/environ/service/TestRecruitment.java
@@ -37,19 +37,16 @@ public class TestRecruitment {
 
     public TestRecruitment addSection(String name, List<NarrativeQuestion> narrativeQuestions,
                                       List<SelectiveQuestion> selectiveQuestions) {
+        narrativeQuestions.forEach(narrativeQuestion -> narrativeQuestion.updateRecruitment(this.recruitment));
+        selectiveQuestions.forEach(selectiveQuestion -> selectiveQuestion.updateRecruitment(this.recruitment));
         Section section = new Section(null, name, DEFAULT_DESCRIPTION, narrativeQuestions, selectiveQuestions);
         section.updateRecruitment(this.recruitment);
         Section savedSection = environ.sectionRepository().save(section);
-        List<NarrativeQuestion> savedNarrativeQuestions = environ.narrativeQuestionRepository()
-                .saveAll(narrativeQuestions);
-        List<SelectiveQuestion> savedSelectiveQuestions = environ.selectiveQuestionRepository()
-                .saveAll(selectiveQuestions);
-        List<Choice> choices = choicesInSelectiveQuestions(selectiveQuestions);
-        List<Choice> savedChoices = environ.choiceRepository().saveAll(choices);
+
         this.sections.add(savedSection);
-        this.narrativeQuestions.addAll(savedNarrativeQuestions);
-        this.selectiveQuestions.addAll(savedSelectiveQuestions);
-        this.choices.addAll(savedChoices);
+        this.narrativeQuestions.addAll(savedSection.getNarrativeQuestions());
+        this.selectiveQuestions.addAll(savedSection.getSelectiveQuestions());
+        this.choices.addAll(choicesInSelectiveQuestions(selectiveQuestions));
         return this;
     }
 

--- a/src/test/java/com/server/crews/environ/service/TestRecruitment.java
+++ b/src/test/java/com/server/crews/environ/service/TestRecruitment.java
@@ -3,7 +3,6 @@ package com.server.crews.environ.service;
 import static com.server.crews.fixture.RecruitmentFixture.DEFAULT_DESCRIPTION;
 
 import com.server.crews.auth.domain.Administrator;
-import com.server.crews.recruitment.domain.Choice;
 import com.server.crews.recruitment.domain.NarrativeQuestion;
 import com.server.crews.recruitment.domain.Recruitment;
 import com.server.crews.recruitment.domain.Section;
@@ -15,17 +14,11 @@ import java.util.List;
 public class TestRecruitment {
     private final ServiceTestEnviron environ;
     private final List<Section> sections;
-    private final List<NarrativeQuestion> narrativeQuestions;
-    private final List<SelectiveQuestion> selectiveQuestions;
-    private final List<Choice> choices;
     private Recruitment recruitment;
 
     public TestRecruitment(ServiceTestEnviron environ) {
         this.environ = environ;
         this.sections = new ArrayList<>();
-        this.narrativeQuestions = new ArrayList<>();
-        this.selectiveQuestions = new ArrayList<>();
-        this.choices = new ArrayList<>();
     }
 
     public TestRecruitment create(String code, String clubName, LocalDateTime deadline, Administrator publisher) {
@@ -44,17 +37,7 @@ public class TestRecruitment {
         Section savedSection = environ.sectionRepository().save(section);
 
         this.sections.add(savedSection);
-        this.narrativeQuestions.addAll(savedSection.getNarrativeQuestions());
-        this.selectiveQuestions.addAll(savedSection.getSelectiveQuestions());
-        this.choices.addAll(choicesInSelectiveQuestions(selectiveQuestions));
         return this;
-    }
-
-    private List<Choice> choicesInSelectiveQuestions(List<SelectiveQuestion> selectiveQuestions) {
-        return selectiveQuestions.stream()
-                .map(SelectiveQuestion::getChoices)
-                .flatMap(List::stream)
-                .toList();
     }
 
     public TestRecruitment start() {
@@ -73,15 +56,7 @@ public class TestRecruitment {
         return this.recruitment;
     }
 
-    public List<NarrativeQuestion> narrativeQuestions() {
-        return this.narrativeQuestions;
-    }
-
-    public List<SelectiveQuestion> selectiveQuestions() {
-        return this.selectiveQuestions;
-    }
-
-    public List<Choice> choices(int questionIndex) {
-        return this.selectiveQuestions.get(questionIndex).getChoices();
+    public List<Section> sections() {
+        return this.sections;
     }
 }

--- a/src/test/java/com/server/crews/fixture/ApplicationFixture.java
+++ b/src/test/java/com/server/crews/fixture/ApplicationFixture.java
@@ -13,10 +13,10 @@ public class ApplicationFixture {
     public static final String DEFAULT_NAME = "DEFAULT_NAME";
     public static final String DEFAULT_NARRATIVE_ANSWER = "DEFAULT_NARRATIVE_ANSWER";
 
-    public static Application APPLICATION(Applicant applicant, Recruitment recruitment,
+    public static Application APPLICATION(Long applicantId, Recruitment recruitment,
                                           List<NarrativeAnswer> narrativeAnswers,
                                           List<SelectiveAnswer> selectiveAnswers) {
-        return new Application(null, recruitment, applicant, DEFAULT_STUDENT_NUMBER, DEFAULT_MAJOR, DEFAULT_NAME,
+        return new Application(null, recruitment, applicantId, DEFAULT_STUDENT_NUMBER, DEFAULT_MAJOR, DEFAULT_NAME,
                 narrativeAnswers, selectiveAnswers);
     }
 }

--- a/src/test/java/com/server/crews/fixture/RecruitmentFixture.java
+++ b/src/test/java/com/server/crews/fixture/RecruitmentFixture.java
@@ -9,7 +9,7 @@ import static com.server.crews.fixture.SectionFixture.FRONTEND_SECTION_NAME;
 import com.server.crews.auth.domain.Administrator;
 import com.server.crews.recruitment.domain.Recruitment;
 import com.server.crews.recruitment.dto.request.QuestionSaveRequest;
-import com.server.crews.recruitment.dto.request.QuestionType;
+import com.server.crews.recruitment.domain.QuestionType;
 import com.server.crews.recruitment.dto.request.RecruitmentSaveRequest;
 import com.server.crews.recruitment.dto.request.SectionSaveRequest;
 import java.time.LocalDateTime;

--- a/src/test/java/com/server/crews/recruitment/application/RecruitmentServiceTest.java
+++ b/src/test/java/com/server/crews/recruitment/application/RecruitmentServiceTest.java
@@ -26,7 +26,7 @@ import com.server.crews.recruitment.domain.RecruitmentProgress;
 import com.server.crews.recruitment.dto.request.ChoiceSaveRequest;
 import com.server.crews.recruitment.dto.request.DeadlineUpdateRequest;
 import com.server.crews.recruitment.dto.request.QuestionSaveRequest;
-import com.server.crews.recruitment.dto.request.QuestionType;
+import com.server.crews.recruitment.domain.QuestionType;
 import com.server.crews.recruitment.dto.request.RecruitmentSaveRequest;
 import com.server.crews.recruitment.dto.request.SectionSaveRequest;
 import com.server.crews.recruitment.dto.response.ChoiceResponse;

--- a/src/test/java/com/server/crews/recruitment/presentation/RecruitmentControllerTest.java
+++ b/src/test/java/com/server/crews/recruitment/presentation/RecruitmentControllerTest.java
@@ -15,7 +15,7 @@ import com.server.crews.environ.presentation.TestAuthArgumentResolverConfig;
 import com.server.crews.global.config.WebMvcConfiguration;
 import com.server.crews.recruitment.application.RecruitmentService;
 import com.server.crews.recruitment.dto.request.QuestionSaveRequest;
-import com.server.crews.recruitment.dto.request.QuestionType;
+import com.server.crews.recruitment.domain.QuestionType;
 import com.server.crews.recruitment.dto.request.RecruitmentSaveRequest;
 import com.server.crews.recruitment.dto.request.SectionSaveRequest;
 import java.time.LocalDateTime;

--- a/src/test/java/com/server/crews/recruitment/util/QuestionSorterTest.java
+++ b/src/test/java/com/server/crews/recruitment/util/QuestionSorterTest.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.server.crews.recruitment.domain.RecruitmentProgress;
-import com.server.crews.recruitment.dto.request.QuestionType;
+import com.server.crews.recruitment.domain.QuestionType;
 import com.server.crews.recruitment.dto.response.ChoiceResponse;
 import com.server.crews.recruitment.dto.response.QuestionResponse;
 import com.server.crews.recruitment.dto.response.RecruitmentDetailsResponse;


### PR DESCRIPTION
## Description 📒

>view에대한 검증보다 도메인 정책에대한 검증을 하도록 하고 FE 요구사항에 맞추어 dto 필드 및 지원서 답변 정렬을 추가하였다. 
아직 코드가 어지럽기 때문에 크게 `모집공고, 지원서 작성, 지원서 조회` 세 개로 도메인을 분리해서 아키텍쳐를 고민해본다.

## Issue 💬

#89
