### PR TITLE
리프레시 토큰 저장소 장애 대응

### DIFF
--- a/src/main/java/com/server/crews/auth/controller/AuthController.java
+++ b/src/main/java/com/server/crews/auth/controller/AuthController.java
@@ -93,7 +93,7 @@ public class AuthController {
      */
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(@AdminAuthentication @ApplicantAuthentication LoginUser loginUser) {
-        refreshTokenService.delete(loginUser.userId(), loginUser.role());
+        refreshTokenService.delete(loginUser.username());
         ResponseCookie cookie = refreshTokenCookieGenerator.generate(0, "");
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())

--- a/src/main/java/com/server/crews/auth/controller/AuthController.java
+++ b/src/main/java/com/server/crews/auth/controller/AuthController.java
@@ -42,7 +42,7 @@ public class AuthController {
     public ResponseEntity<TokenResponse> registerForAdmin(@RequestBody AdminLoginRequest request) {
         TokenResponse tokenResponse = authService.registerForAdmin(request);
         RefreshToken refreshToken = refreshTokenService.createRefreshToken(Role.ADMIN, tokenResponse.username());
-        ResponseCookie cookie = refreshTokenCookieGenerator.generateWithDefaultValidity(refreshToken.getToken());
+        ResponseCookie cookie = refreshTokenCookieGenerator.generate(refreshToken);
         return ResponseEntity.status(HttpStatus.OK)
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
                 .body(tokenResponse);
@@ -55,7 +55,7 @@ public class AuthController {
     public ResponseEntity<TokenResponse> loginForAdmin(@RequestBody AdminLoginRequest request) {
         TokenResponse tokenResponse = authService.loginForAdmin(request);
         RefreshToken refreshToken = refreshTokenService.createRefreshToken(Role.ADMIN, tokenResponse.username());
-        ResponseCookie cookie = refreshTokenCookieGenerator.generateWithDefaultValidity(refreshToken.getToken());
+        ResponseCookie cookie = refreshTokenCookieGenerator.generate(refreshToken);
         return ResponseEntity.status(HttpStatus.OK)
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
                 .body(tokenResponse);
@@ -68,7 +68,7 @@ public class AuthController {
     public ResponseEntity<TokenResponse> registerForApplicant(@RequestBody ApplicantLoginRequest request) {
         TokenResponse tokenResponse = authService.registerForApplicant(request);
         RefreshToken refreshToken = refreshTokenService.createRefreshToken(Role.APPLICANT, tokenResponse.username());
-        ResponseCookie cookie = refreshTokenCookieGenerator.generateWithDefaultValidity(refreshToken.getToken());
+        ResponseCookie cookie = refreshTokenCookieGenerator.generate(refreshToken);
         return ResponseEntity.status(HttpStatus.OK)
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
                 .body(tokenResponse);
@@ -81,7 +81,7 @@ public class AuthController {
     public ResponseEntity<TokenResponse> loginForApplicant(@RequestBody ApplicantLoginRequest request) {
         TokenResponse tokenResponse = authService.loginForApplicant(request);
         RefreshToken refreshToken = refreshTokenService.createRefreshToken(Role.APPLICANT, tokenResponse.username());
-        ResponseCookie cookie = refreshTokenCookieGenerator.generateWithDefaultValidity(refreshToken.getToken());
+        ResponseCookie cookie = refreshTokenCookieGenerator.generate(refreshToken);
         return ResponseEntity.status(HttpStatus.OK)
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
                 .body(tokenResponse);
@@ -92,7 +92,7 @@ public class AuthController {
      */
     @PostMapping("/refresh")
     public ResponseEntity<TokenResponse> renew(@CookieValue("refreshToken") String refreshToken) {
-        return ResponseEntity.ok(refreshTokenService.renew(refreshToken)); // FE 와 상의
+        return ResponseEntity.ok(refreshTokenService.renew(refreshToken));
     }
 
     /**

--- a/src/main/java/com/server/crews/auth/controller/AuthController.java
+++ b/src/main/java/com/server/crews/auth/controller/AuthController.java
@@ -1,15 +1,15 @@
 package com.server.crews.auth.controller;
 
-import com.server.crews.auth.service.AuthService;
-import com.server.crews.auth.service.RefreshTokenCookieGenerator;
-import com.server.crews.auth.service.RefreshTokenService;
 import com.server.crews.auth.domain.RefreshToken;
 import com.server.crews.auth.domain.Role;
 import com.server.crews.auth.dto.LoginUser;
 import com.server.crews.auth.dto.request.AdminLoginRequest;
 import com.server.crews.auth.dto.request.ApplicantLoginRequest;
 import com.server.crews.auth.dto.response.TokenResponse;
-import lombok.RequiredArgsConstructor;
+import com.server.crews.auth.service.AuthService;
+import com.server.crews.auth.service.RefreshTokenCookieGenerator;
+import com.server.crews.auth.service.RefreshTokenService;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
@@ -22,11 +22,18 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping(value = "/auth")
-@RequiredArgsConstructor
 public class AuthController {
-    private final RefreshTokenService refreshTokenService;
     private final AuthService authService;
     private final RefreshTokenCookieGenerator refreshTokenCookieGenerator;
+    private final RefreshTokenService refreshTokenService;
+
+    public AuthController(AuthService authService,
+                          RefreshTokenCookieGenerator refreshTokenCookieGenerator,
+                          @Qualifier("refreshTokenStorageFailureHandler") RefreshTokenService refreshTokenService) {
+        this.refreshTokenService = refreshTokenService;
+        this.authService = authService;
+        this.refreshTokenCookieGenerator = refreshTokenCookieGenerator;
+    }
 
     /**
      * [동아리 관리자] 회원가입하고 토큰을 발급 받는다.
@@ -85,7 +92,7 @@ public class AuthController {
      */
     @PostMapping("/refresh")
     public ResponseEntity<TokenResponse> renew(@CookieValue("refreshToken") String refreshToken) {
-        return ResponseEntity.ok(refreshTokenService.renew(refreshToken));
+        return ResponseEntity.ok(refreshTokenService.renew(refreshToken)); // FE 와 상의
     }
 
     /**

--- a/src/main/java/com/server/crews/auth/domain/RefreshToken.java
+++ b/src/main/java/com/server/crews/auth/domain/RefreshToken.java
@@ -15,13 +15,13 @@ public class RefreshToken {
     private String username;
 
     @TimeToLive
-    private Long validity;
+    private Long validityInSeconds;
 
     private String token;
 
-    public RefreshToken(String username, Long validity, String token) {
+    public RefreshToken(String username, Long validityInSeconds, String token) {
         this.username = username;
-        this.validity = validity;
+        this.validityInSeconds = validityInSeconds;
         this.token = token;
     }
 

--- a/src/main/java/com/server/crews/auth/dto/LoginUser.java
+++ b/src/main/java/com/server/crews/auth/dto/LoginUser.java
@@ -2,5 +2,5 @@ package com.server.crews.auth.dto;
 
 import com.server.crews.auth.domain.Role;
 
-public record LoginUser(Long userId, Role role) {
+public record LoginUser(Long userId, String username, Role role) {
 }

--- a/src/main/java/com/server/crews/auth/service/AuthService.java
+++ b/src/main/java/com/server/crews/auth/service/AuthService.java
@@ -92,7 +92,7 @@ public class AuthService {
         String clubName = jwtTokenProvider.getPayload(accessToken);
         Administrator administrator = administratorRepository.findByClubName(clubName)
                 .orElseThrow(() -> new CrewsException(CrewsErrorCode.USER_NOT_FOUND));
-        return new LoginUser(administrator.getId(), Role.ADMIN);
+        return new LoginUser(administrator.getId(), administrator.getClubName(), Role.ADMIN);
     }
 
     private void validateAdminAuthorization(String accessToken) {
@@ -108,7 +108,7 @@ public class AuthService {
         String email = jwtTokenProvider.getPayload(accessToken);
         Applicant applicant = applicantRepository.findByEmail(email)
                 .orElseThrow(() -> new CrewsException(CrewsErrorCode.USER_NOT_FOUND));
-        return new LoginUser(applicant.getId(), Role.APPLICANT);
+        return new LoginUser(applicant.getId(), applicant.getEmail(), Role.APPLICANT);
     }
 
     private void validateApplicantAuthorization(String accessToken) {
@@ -125,10 +125,10 @@ public class AuthService {
         if (role == Role.APPLICANT) {
             Applicant applicant = applicantRepository.findByEmail(payload)
                     .orElseThrow(() -> new CrewsException(CrewsErrorCode.USER_NOT_FOUND));
-            return new LoginUser(applicant.getId(), Role.APPLICANT);
+            return new LoginUser(applicant.getId(), applicant.getEmail(), Role.APPLICANT);
         }
         Administrator administrator = administratorRepository.findByClubName(payload)
                 .orElseThrow(() -> new CrewsException(CrewsErrorCode.USER_NOT_FOUND));
-        return new LoginUser(administrator.getId(), Role.ADMIN);
+        return new LoginUser(administrator.getId(), administrator.getClubName(), Role.ADMIN);
     }
 }

--- a/src/main/java/com/server/crews/auth/service/AuthService.java
+++ b/src/main/java/com/server/crews/auth/service/AuthService.java
@@ -52,12 +52,20 @@ public class AuthService {
     public TokenResponse registerForApplicant(ApplicantLoginRequest request) {
         String email = request.email();
         String password = request.password();
+        validateDuplicatedEmail(email);
 
         String encodedPassword = passwordEncoder.encode(password);
         Applicant applicant = new Applicant(email, encodedPassword);
         applicantRepository.save(applicant);
         String accessToken = jwtTokenProvider.createAccessToken(Role.APPLICANT, email);
         return new TokenResponse(applicant.getEmail(), accessToken);
+    }
+
+    private void validateDuplicatedEmail(String email) {
+        applicantRepository.findByEmail(email)
+                .ifPresent(applicant -> {
+                    throw new CrewsException(CrewsErrorCode.DUPLICATED_EMAIL);
+                });
     }
 
     public TokenResponse loginForApplicant(ApplicantLoginRequest request) {

--- a/src/main/java/com/server/crews/auth/service/RefreshTokenCookieGenerator.java
+++ b/src/main/java/com/server/crews/auth/service/RefreshTokenCookieGenerator.java
@@ -1,6 +1,6 @@
 package com.server.crews.auth.service;
 
-import org.springframework.beans.factory.annotation.Value;
+import com.server.crews.auth.domain.RefreshToken;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
@@ -9,14 +9,8 @@ public class RefreshTokenCookieGenerator {
     private static final String COOKIE_NAME = "refreshToken";
     private static final String COOKIE_PATH = "/auth/refresh";
 
-    private final int defaultTokenValidity;
-
-    public RefreshTokenCookieGenerator(@Value("${jwt.refresh-token-validity}") int refreshTokenValidityInMilliseconds) {
-        this.defaultTokenValidity = refreshTokenValidityInMilliseconds / 1000;
-    }
-
-    public ResponseCookie generateWithDefaultValidity(String token) {
-        return generate(this.defaultTokenValidity, token);
+    public ResponseCookie generate(RefreshToken refreshToken) {
+        return generate(refreshToken.getValidityInSeconds(), refreshToken.getToken());
     }
 
     public ResponseCookie generate(long validity, String token) {

--- a/src/main/java/com/server/crews/auth/service/RefreshTokenManager.java
+++ b/src/main/java/com/server/crews/auth/service/RefreshTokenManager.java
@@ -1,0 +1,43 @@
+package com.server.crews.auth.service;
+
+import com.server.crews.auth.domain.RefreshToken;
+import com.server.crews.auth.domain.Role;
+import com.server.crews.auth.dto.response.TokenResponse;
+import com.server.crews.auth.repository.RefreshTokenRepository;
+import com.server.crews.global.exception.CrewsErrorCode;
+import com.server.crews.global.exception.CrewsException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenManager implements RefreshTokenService {
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Override
+    public RefreshToken createRefreshToken(Role role, String username) {
+        RefreshToken refreshToken = jwtTokenProvider.createRefreshToken(role, username);
+        return refreshTokenRepository.save(refreshToken);
+    }
+
+    @Override
+    public TokenResponse renew(String refreshToken) {
+        jwtTokenProvider.validateRefreshToken(refreshToken);
+        String username = jwtTokenProvider.getPayload(refreshToken);
+        RefreshToken savedRefreshToken = refreshTokenRepository.findById(username)
+                .orElseThrow(() -> new CrewsException(CrewsErrorCode.REFRESH_TOKEN_NOT_FOUND));
+        if (!savedRefreshToken.isSameToken(refreshToken)) {
+            throw new CrewsException(CrewsErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        Role role = jwtTokenProvider.getRole(refreshToken);
+        String accessToken = jwtTokenProvider.createAccessToken(role, username);
+        return new TokenResponse(username, accessToken);
+    }
+
+    @Override
+    public void delete(String username) {
+        refreshTokenRepository.deleteById(username);
+    }
+}

--- a/src/main/java/com/server/crews/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/server/crews/auth/service/RefreshTokenService.java
@@ -3,38 +3,12 @@ package com.server.crews.auth.service;
 import com.server.crews.auth.domain.RefreshToken;
 import com.server.crews.auth.domain.Role;
 import com.server.crews.auth.dto.response.TokenResponse;
-import com.server.crews.auth.repository.RefreshTokenRepository;
-import com.server.crews.global.exception.CrewsErrorCode;
-import com.server.crews.global.exception.CrewsException;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
-@Service
-@RequiredArgsConstructor
-public class RefreshTokenService {
-    private final JwtTokenProvider jwtTokenProvider;
-    private final RefreshTokenRepository refreshTokenRepository;
+public interface RefreshTokenService {
 
-    public RefreshToken createRefreshToken(Role role, String username) {
-        RefreshToken refreshToken = jwtTokenProvider.createRefreshToken(role, username);
-        return refreshTokenRepository.save(refreshToken);
-    }
+    RefreshToken createRefreshToken(Role role, String username);
 
-    public TokenResponse renew(String refreshToken) {
-        jwtTokenProvider.validateRefreshToken(refreshToken);
-        String username = jwtTokenProvider.getPayload(refreshToken);
-        RefreshToken savedRefreshToken = refreshTokenRepository.findById(username)
-                .orElseThrow(() -> new CrewsException(CrewsErrorCode.REFRESH_TOKEN_NOT_FOUND));
-        if (!savedRefreshToken.isSameToken(refreshToken)) {
-            throw new CrewsException(CrewsErrorCode.INVALID_REFRESH_TOKEN);
-        }
+    TokenResponse renew(String refreshToken);
 
-        Role role = jwtTokenProvider.getRole(refreshToken);
-        String accessToken = jwtTokenProvider.createAccessToken(role, username);
-        return new TokenResponse(username, accessToken);
-    }
-
-    public void delete(String username) {
-        refreshTokenRepository.deleteById(username);
-    }
+    void delete(String username);
 }

--- a/src/main/java/com/server/crews/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/server/crews/auth/service/RefreshTokenService.java
@@ -1,29 +1,20 @@
 package com.server.crews.auth.service;
 
-import com.server.crews.auth.domain.Administrator;
-import com.server.crews.auth.domain.Applicant;
 import com.server.crews.auth.domain.RefreshToken;
 import com.server.crews.auth.domain.Role;
 import com.server.crews.auth.dto.response.TokenResponse;
-import com.server.crews.auth.repository.AdministratorRepository;
-import com.server.crews.auth.repository.ApplicantRepository;
 import com.server.crews.auth.repository.RefreshTokenRepository;
-import com.server.crews.global.exception.CrewsException;
 import com.server.crews.global.exception.CrewsErrorCode;
+import com.server.crews.global.exception.CrewsException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class RefreshTokenService {
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
-    private final AdministratorRepository administratorRepository;
-    private final ApplicantRepository applicantRepository;
 
-    @Transactional
     public RefreshToken createRefreshToken(Role role, String username) {
         RefreshToken refreshToken = jwtTokenProvider.createRefreshToken(role, username);
         return refreshTokenRepository.save(refreshToken);
@@ -43,15 +34,7 @@ public class RefreshTokenService {
         return new TokenResponse(username, accessToken);
     }
 
-    public void delete(Long userId, Role role) {
-        if (role == Role.ADMIN) {
-            Administrator administrator = administratorRepository.findById(userId)
-                    .orElseThrow(() -> new CrewsException(CrewsErrorCode.USER_NOT_FOUND));
-            refreshTokenRepository.deleteById(administrator.getClubName());
-            return;
-        }
-        Applicant applicant = applicantRepository.findById(userId)
-                .orElseThrow(() -> new CrewsException(CrewsErrorCode.USER_NOT_FOUND));
-        refreshTokenRepository.deleteById(applicant.getEmail());
+    public void delete(String username) {
+        refreshTokenRepository.deleteById(username);
     }
 }

--- a/src/main/java/com/server/crews/auth/service/RefreshTokenStorageFailureHandler.java
+++ b/src/main/java/com/server/crews/auth/service/RefreshTokenStorageFailureHandler.java
@@ -1,0 +1,54 @@
+package com.server.crews.auth.service;
+
+import com.server.crews.auth.domain.RefreshToken;
+import com.server.crews.auth.domain.Role;
+import com.server.crews.auth.dto.response.TokenResponse;
+import com.server.crews.global.CustomLogger;
+import io.lettuce.core.RedisCommandTimeoutException;
+import io.lettuce.core.RedisException;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.RedisSystemException;
+import org.springframework.stereotype.Service;
+
+/*
+    Decorator 패턴을 활용해서 RefreshTokenService에서 저장소 관련 예외가 발생한 경우를 처리한다.
+ */
+@Service
+public class RefreshTokenStorageFailureHandler implements RefreshTokenService {
+    private final RefreshTokenService refreshTokenService;
+    private final CustomLogger customLogger;
+
+    public RefreshTokenStorageFailureHandler(
+            @Qualifier("refreshTokenManager") RefreshTokenService refreshTokenService) {
+        this.refreshTokenService = refreshTokenService;
+        this.customLogger = new CustomLogger(RefreshTokenStorageFailureHandler.class);
+    }
+
+    @Override
+    public RefreshToken createRefreshToken(Role role, String username) {
+        try {
+            return refreshTokenService.createRefreshToken(role, username);
+        } catch (RedisConnectionFailureException | RedisSystemException | RedisException e) {
+            customLogger.error(e);
+            return new RefreshToken("", 0l, "");
+        }
+    }
+
+    /*
+    500 에러를 그대로 반환한다.
+     */
+    @Override
+    public TokenResponse renew(String refreshToken) {
+        return refreshTokenService.renew(refreshToken);
+    }
+
+    @Override
+    public void delete(String username) {
+        try {
+            refreshTokenService.delete(username);
+        } catch (RedisConnectionFailureException | RedisCommandTimeoutException | RedisSystemException e) {
+            customLogger.error(e);
+        }
+    }
+}

--- a/src/main/java/com/server/crews/global/CustomLogger.java
+++ b/src/main/java/com/server/crews/global/CustomLogger.java
@@ -13,8 +13,10 @@ public class CustomLogger {
     }
 
     public void error(Exception e) {
-        MDC.put("lineNumber", String.valueOf(e.getStackTrace()[0].getLineNumber()));
-        MDC.put("className", e.getStackTrace()[0].getClassName());
+        if (e.getStackTrace().length > 0) {
+            MDC.put("lineNumber", String.valueOf(e.getStackTrace()[0].getLineNumber()));
+            MDC.put("className", e.getStackTrace()[0].getClassName());
+        }
         MDC.put("exceptionName", e.getClass().getSimpleName());
         MDC.put("exceptionMessage", e.getMessage());
         MDC.put("stackTrace", extractStackTrace(e));

--- a/src/main/java/com/server/crews/global/exception/CrewsErrorCode.java
+++ b/src/main/java/com/server/crews/global/exception/CrewsErrorCode.java
@@ -29,6 +29,7 @@ public enum CrewsErrorCode {
     UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "권한이 없는 사용자입니다.", 1020),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "존재하지 않는 리프레시 토큰입니다.", 1021),
     WRONG_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다.", 1022),
+    DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "이미 가입된 지원자 이메일입니다.", 1026),
 
     ANSWER_REQUIRED(HttpStatus.BAD_REQUEST, "필수 문항의 답변이 없습니다.", 1023),
     EXCEED_WORD_LIMIT_ANSWER(HttpStatus.BAD_REQUEST, "서술형 문항의 글자수 제한을 초과했습니다.", 1024),

--- a/src/test/java/com/server/crews/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/server/crews/auth/service/AuthServiceTest.java
@@ -1,7 +1,9 @@
 package com.server.crews.auth.service;
 
+import static com.server.crews.fixture.UserFixture.TEST_EMAIL;
 import static com.server.crews.fixture.UserFixture.TEST_PASSWORD;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.server.crews.auth.domain.Administrator;
@@ -14,6 +16,8 @@ import com.server.crews.auth.dto.response.TokenResponse;
 import com.server.crews.auth.repository.AdministratorRepository;
 import com.server.crews.auth.repository.ApplicantRepository;
 import com.server.crews.environ.service.ServiceTest;
+import com.server.crews.global.exception.CrewsErrorCode;
+import com.server.crews.global.exception.CrewsException;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -86,6 +90,19 @@ class AuthServiceTest extends ServiceTest {
             softAssertions.assertThat(createdApplicant).isNotEmpty();
             softAssertions.assertThat(tokenResponse.accessToken()).isNotNull();
         });
+    }
+
+    @Test
+    @DisplayName("지원자는 중복된 이메일로 회원가입할 수 없다.")
+    void validateDuplicatedEmail() {
+        // given
+        ApplicantLoginRequest request = new ApplicantLoginRequest(TEST_EMAIL, TEST_PASSWORD);
+        authService.registerForApplicant(request);
+
+        // when & then
+        assertThatThrownBy(() -> authService.registerForApplicant(request))
+                .isInstanceOf(CrewsException.class)
+                .hasMessage(CrewsErrorCode.DUPLICATED_EMAIL.getMessage());
     }
 
     @Test

--- a/src/test/java/com/server/crews/auth/service/RefreshTokenManagerTest.java
+++ b/src/test/java/com/server/crews/auth/service/RefreshTokenManagerTest.java
@@ -1,7 +1,6 @@
 package com.server.crews.auth.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import com.server.crews.auth.domain.RefreshToken;
 import com.server.crews.auth.domain.Role;
@@ -11,10 +10,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-class RefreshTokenServiceTest extends ServiceTest {
+class RefreshTokenManagerTest extends ServiceTest {
 
     @Autowired
-    private RefreshTokenService refreshTokenService;
+    private RefreshTokenManager refreshTokenManager;
 
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
@@ -27,7 +26,7 @@ class RefreshTokenServiceTest extends ServiceTest {
         String username = "mia";
 
         // when
-        RefreshToken refreshToken = refreshTokenService.createRefreshToken(role, username);
+        RefreshToken refreshToken = refreshTokenManager.createRefreshToken(role, username);
 
         // then
         assertThat(refreshToken.getUsername()).isEqualTo(username);
@@ -39,10 +38,10 @@ class RefreshTokenServiceTest extends ServiceTest {
         // given
         Role role = Role.APPLICANT;
         String username = "mia";
-        RefreshToken refreshToken = refreshTokenService.createRefreshToken(role, username);
+        RefreshToken refreshToken = refreshTokenManager.createRefreshToken(role, username);
 
         // when
-        TokenResponse tokenResponse = refreshTokenService.renew(refreshToken.getToken());
+        TokenResponse tokenResponse = refreshTokenManager.renew(refreshToken.getToken());
 
         // then
         assertThat(tokenResponse.username()).isEqualTo(username);

--- a/src/test/java/com/server/crews/auth/service/RefreshTokenStorageFailureHandlerTest.java
+++ b/src/test/java/com/server/crews/auth/service/RefreshTokenStorageFailureHandlerTest.java
@@ -1,0 +1,43 @@
+package com.server.crews.auth.service;
+
+import static com.server.crews.fixture.UserFixture.TEST_EMAIL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+
+import com.server.crews.auth.domain.RefreshToken;
+import com.server.crews.auth.domain.Role;
+import com.server.crews.auth.repository.RefreshTokenRepository;
+import com.server.crews.environ.service.ServiceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.redis.RedisConnectionFailureException;
+
+class RefreshTokenStorageFailureHandlerTest extends ServiceTest {
+
+    @Autowired
+    private RefreshTokenStorageFailureHandler refreshTokenStorageFailureHandler;
+
+    @MockBean
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Test
+    @DisplayName("리프레시 토큰을 생성할 때 저장소에 장애가 발생하면 만료시간이 0인 빈 토큰을 받는다.")
+    void createRefreshToken() {
+        // given
+        BDDMockito.given(refreshTokenRepository.save(any()))
+                .willThrow(RedisConnectionFailureException.class);
+
+        // when
+        RefreshToken refreshToken = refreshTokenStorageFailureHandler.createRefreshToken(Role.APPLICANT, TEST_EMAIL);
+
+        // then
+        assertAll(() -> {
+            assertThat(refreshToken.getToken()).isEqualTo("");
+            assertThat(refreshToken.getValidity()).isEqualTo(0l);
+        });
+    }
+}

--- a/src/test/java/com/server/crews/auth/service/RefreshTokenStorageFailureHandlerTest.java
+++ b/src/test/java/com/server/crews/auth/service/RefreshTokenStorageFailureHandlerTest.java
@@ -37,7 +37,7 @@ class RefreshTokenStorageFailureHandlerTest extends ServiceTest {
         // then
         assertAll(() -> {
             assertThat(refreshToken.getToken()).isEqualTo("");
-            assertThat(refreshToken.getValidity()).isEqualTo(0l);
+            assertThat(refreshToken.getValidityInSeconds()).isEqualTo(0l);
         });
     }
 }

--- a/src/test/java/com/server/crews/environ/presentation/FakeAuthenticationArgumentResolver.java
+++ b/src/test/java/com/server/crews/environ/presentation/FakeAuthenticationArgumentResolver.java
@@ -1,5 +1,8 @@
 package com.server.crews.environ.presentation;
 
+import static com.server.crews.fixture.UserFixture.TEST_CLUB_NAME;
+import static com.server.crews.fixture.UserFixture.TEST_EMAIL;
+
 import com.server.crews.auth.domain.Role;
 import com.server.crews.auth.dto.LoginUser;
 import com.server.crews.auth.controller.AdminAuthentication;
@@ -10,8 +13,8 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 public class FakeAuthenticationArgumentResolver extends AuthenticationArgumentResolver {
-    public static LoginUser FAKE_ADMIN_LOGIN_USER = new LoginUser(1L, Role.ADMIN);
-    public static LoginUser FAKE_APPLICANT_LOGIN_USER = new LoginUser(1L, Role.APPLICANT);
+    public static LoginUser FAKE_ADMIN_LOGIN_USER = new LoginUser(1L, TEST_CLUB_NAME, Role.ADMIN);
+    public static LoginUser FAKE_APPLICANT_LOGIN_USER = new LoginUser(1L, TEST_EMAIL, Role.APPLICANT);
 
     public FakeAuthenticationArgumentResolver() {
         super(null);


### PR DESCRIPTION
## Description 📒

>리프레시 토큰 저장소에 장애가 나더라도 회원가입/로그인/로그아웃 기능이 정상 작동하도록 한다. 단, 액세스 토큰 재발급은 불가하다.

## Issue 💬

#103
