### PR TITLE
한 지원자가 여러 모집 공고에 지원할 수 있도록 수정, 모집공고 조회에서 N+1 문제 해결

### DIFF
--- a/src/main/java/com/server/crews/applicant/repository/ApplicationRepository.java
+++ b/src/main/java/com/server/crews/applicant/repository/ApplicationRepository.java
@@ -52,6 +52,6 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
             select a from Application a
             where a.applicant.id = :applicantId and a.recruitment.id = :recruitmentId
             """)
-    Optional<Application> findByApplicantId(@Param("applicantId") Long applicantId,
-                                            @Param("recruitmentId") Long recruitmentId);
+    Optional<Application> findByApplicantIdAndRecruitmentId(@Param("applicantId") Long applicantId,
+                                                            @Param("recruitmentId") Long recruitmentId);
 }

--- a/src/main/java/com/server/crews/applicant/repository/ApplicationRepository.java
+++ b/src/main/java/com/server/crews/applicant/repository/ApplicationRepository.java
@@ -50,7 +50,8 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
     @EntityGraph(attributePaths = {"narrativeAnswers", "selectiveAnswers"})
     @Query("""
             select a from Application a
-            where a.applicant.id = :applicantId
+            where a.applicant.id = :applicantId and a.recruitment.id = :recruitmentId
             """)
-    Optional<Application> findByApplicantId(@Param("applicantId") Long applicantId);
+    Optional<Application> findByApplicantId(@Param("applicantId") Long applicantId,
+                                            @Param("recruitmentId") Long recruitmentId);
 }

--- a/src/main/java/com/server/crews/applicant/service/ApplicationService.java
+++ b/src/main/java/com/server/crews/applicant/service/ApplicationService.java
@@ -39,7 +39,8 @@ public class ApplicationService {
         List<NarrativeAnswer> newNarrativeAnswers = ApplicationMapper.narrativeAnswersInApplicationSaveRequest(request);
         List<SelectiveAnswer> newSelectiveAnswers = ApplicationMapper.selectiveAnswersInApplicationSaveRequest(request);
 
-        Application previosApplication = applicationRepository.findByApplicantId(applicantId).orElse(null);
+        Application previosApplication = applicationRepository.findByApplicantId(applicantId, recruitment.getId())
+                .orElse(null);
         List<NarrativeAnswer> updatedNarrativeAnswers = applicationManager.writeNarrativeAnswers(recruitment,
                 previosApplication, newNarrativeAnswers);
         List<SelectiveAnswer> updatedSelectiveAnswers = applicationManager.writeSelectiveAnswers(recruitment,

--- a/src/main/java/com/server/crews/applicant/service/ApplicationService.java
+++ b/src/main/java/com/server/crews/applicant/service/ApplicationService.java
@@ -39,7 +39,7 @@ public class ApplicationService {
         List<NarrativeAnswer> newNarrativeAnswers = ApplicationMapper.narrativeAnswersInApplicationSaveRequest(request);
         List<SelectiveAnswer> newSelectiveAnswers = ApplicationMapper.selectiveAnswersInApplicationSaveRequest(request);
 
-        Application previosApplication = applicationRepository.findByApplicantId(applicantId, recruitment.getId())
+        Application previosApplication = applicationRepository.findByApplicantIdAndRecruitmentId(applicantId, recruitment.getId())
                 .orElse(null);
         List<NarrativeAnswer> updatedNarrativeAnswers = applicationManager.writeNarrativeAnswers(recruitment,
                 previosApplication, newNarrativeAnswers);

--- a/src/main/java/com/server/crews/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/server/crews/recruitment/domain/Recruitment.java
@@ -1,7 +1,5 @@
 package com.server.crews.recruitment.domain;
 
-import static java.util.stream.Collectors.groupingBy;
-
 import com.server.crews.auth.domain.Administrator;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -26,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -113,19 +110,9 @@ public class Recruitment {
         this.code = code;
     }
 
-    public void replaceQuestionsWithFetchedData(List<NarrativeQuestion> narrativeQuestions,
-                                                List<SelectiveQuestion> selectiveQuestions) {
-        Map<Long, List<NarrativeQuestion>> narrativeQuestionsBySectionId = narrativeQuestions.stream()
-                .collect(groupingBy(NarrativeQuestion::getSectionId));
-        Map<Long, List<SelectiveQuestion>> selectiveQuestionsBySectionId = selectiveQuestions.stream()
-                .collect(groupingBy(SelectiveQuestion::getSectionId));
-
-        sections.forEach(section ->
-                section.replaceQuestions(
-                        narrativeQuestionsBySectionId.getOrDefault(section.getId(), List.of()),
-                        selectiveQuestionsBySectionId.getOrDefault(section.getId(), List.of())
-                )
-        );
+    public void replaceSectionsWithFetchedData(List<Section> sections) {
+        this.sections.clear();
+        this.sections.addAll(sections);
     }
 
     public void start() {

--- a/src/main/java/com/server/crews/recruitment/domain/Section.java
+++ b/src/main/java/com/server/crews/recruitment/domain/Section.java
@@ -16,7 +16,9 @@ import jakarta.persistence.Table;
 import jakarta.validation.constraints.Size;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -43,28 +45,20 @@ public class Section {
     private String description;
 
     @OneToMany(mappedBy = "section", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<NarrativeQuestion> narrativeQuestions = new ArrayList<>();
+    private Set<NarrativeQuestion> narrativeQuestions = new HashSet<>();
 
     @OneToMany(mappedBy = "section", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<SelectiveQuestion> selectiveQuestions = new ArrayList<>();
+    private Set<SelectiveQuestion> selectiveQuestions = new HashSet<>();
 
     public Section(Long id, String name, String description, List<NarrativeQuestion> narrativeQuestions,
                    List<SelectiveQuestion> selectiveQuestions) {
         this.id = id;
         this.name = name;
         this.description = description;
-        replaceQuestions(narrativeQuestions, selectiveQuestions);
-    }
-
-    Section replaceQuestions(List<NarrativeQuestion> narrativeQuestions,
-                             List<SelectiveQuestion> selectiveQuestions) {
         narrativeQuestions.forEach(narrativeQuestion -> narrativeQuestion.updateSection(this));
-        this.narrativeQuestions.clear();
         this.narrativeQuestions.addAll(narrativeQuestions);
         selectiveQuestions.forEach(selectiveQuestion -> selectiveQuestion.updateSection(this));
-        this.selectiveQuestions.clear();
         this.selectiveQuestions.addAll(selectiveQuestions);
-        return this;
     }
 
     public List<Question> getOrderedQuestions() {
@@ -77,5 +71,13 @@ public class Section {
 
     public void updateRecruitment(Recruitment recruitment) {
         this.recruitment = recruitment;
+    }
+
+    public List<NarrativeQuestion> getNarrativeQuestions() {
+        return new ArrayList<>(narrativeQuestions);
+    }
+
+    public List<SelectiveQuestion> getSelectiveQuestions() {
+        return new ArrayList<>(selectiveQuestions);
     }
 }

--- a/src/main/java/com/server/crews/recruitment/repository/NarrativeQuestionRepository.java
+++ b/src/main/java/com/server/crews/recruitment/repository/NarrativeQuestionRepository.java
@@ -3,18 +3,8 @@ package com.server.crews.recruitment.repository;
 import com.server.crews.recruitment.domain.NarrativeQuestion;
 import com.server.crews.recruitment.domain.Section;
 import java.util.List;
-import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface NarrativeQuestionRepository extends JpaRepository<NarrativeQuestion, Long> {
     List<NarrativeQuestion> findAllBySectionIn(List<Section> sections);
-
-    List<NarrativeQuestion> findAllByIdIn(Set<Long> questionIds);
-
-    @Query("""
-            select n from NarrativeQuestion n
-            where n.recruitment.id = :recruitmentId
-            """)
-    List<NarrativeQuestion> findAllByRecruitmentId(Long recruitmentId);
 }

--- a/src/main/java/com/server/crews/recruitment/repository/SectionRepository.java
+++ b/src/main/java/com/server/crews/recruitment/repository/SectionRepository.java
@@ -1,7 +1,18 @@
 package com.server.crews.recruitment.repository;
 
 import com.server.crews.recruitment.domain.Section;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SectionRepository extends JpaRepository<Section, Long> {
+
+    @Query("""
+            select s from Section s
+            join fetch s.narrativeQuestions
+            join fetch s.selectiveQuestions
+            where s.recruitment.id = :recruitmentId
+            """)
+    List<Section> findAllWithQuestionsByRecruitmentId(@Param("recruitmentId") Long recruitmentId);
 }

--- a/src/main/java/com/server/crews/recruitment/repository/SelectiveQuestionRepository.java
+++ b/src/main/java/com/server/crews/recruitment/repository/SelectiveQuestionRepository.java
@@ -3,24 +3,15 @@ package com.server.crews.recruitment.repository;
 import com.server.crews.recruitment.domain.Section;
 import com.server.crews.recruitment.domain.SelectiveQuestion;
 import java.util.List;
-import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface SelectiveQuestionRepository extends JpaRepository<SelectiveQuestion, Long> {
-    List<SelectiveQuestion> findAllByIdIn(Set<Long> questionIds);
-
     @Query("""
             select s from SelectiveQuestion s
             left join fetch s.choices
             where s.section in :sections
             """)
     List<SelectiveQuestion> findAllWithChoicesInSections(@Param("sections") List<Section> sections);
-
-    @Query("""
-            select s from SelectiveQuestion s
-            where s.recruitment.id = :recruitmentId
-            """)
-    List<SelectiveQuestion> findAllByRecruitmentId(@Param("recruitmentId") Long recruitmentId);
 }

--- a/src/main/java/com/server/crews/recruitment/service/RecruitmentDetailsLoader.java
+++ b/src/main/java/com/server/crews/recruitment/service/RecruitmentDetailsLoader.java
@@ -1,12 +1,10 @@
 package com.server.crews.recruitment.service;
 
 import com.server.crews.global.exception.NotFoundException;
-import com.server.crews.recruitment.domain.NarrativeQuestion;
 import com.server.crews.recruitment.domain.Recruitment;
-import com.server.crews.recruitment.domain.SelectiveQuestion;
-import com.server.crews.recruitment.repository.NarrativeQuestionRepository;
+import com.server.crews.recruitment.domain.Section;
 import com.server.crews.recruitment.repository.RecruitmentRepository;
-import com.server.crews.recruitment.repository.SelectiveQuestionRepository;
+import com.server.crews.recruitment.repository.SectionRepository;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -18,8 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class RecruitmentDetailsLoader {
     private final RecruitmentRepository recruitmentRepository;
-    private final NarrativeQuestionRepository narrativeQuestionRepository;
-    private final SelectiveQuestionRepository selectiveQuestionRepository;
+    private final SectionRepository sectionRepository;
 
     public Recruitment findWithSectionsByCode(String code) {
         Recruitment recruitment = recruitmentRepository.findWithSectionsByCode(code)
@@ -46,9 +43,8 @@ public class RecruitmentDetailsLoader {
 
     private Recruitment fetchQuestions(Recruitment recruitment) {
         Long recruitmentId = recruitment.getId();
-        List<NarrativeQuestion> narrativeQuestions = narrativeQuestionRepository.findAllByRecruitmentId(recruitmentId);
-        List<SelectiveQuestion> selectiveQuestions = selectiveQuestionRepository.findAllByRecruitmentId(recruitmentId);
-        recruitment.replaceQuestionsWithFetchedData(narrativeQuestions, selectiveQuestions);
+        List<Section> sections = sectionRepository.findAllWithQuestionsByRecruitmentId(recruitmentId);
+        recruitment.replaceSectionsWithFetchedData(sections);
         return recruitment;
     }
 }


### PR DESCRIPTION
## Description 📒
### 한 지원자가 여러 모집 공고에 지원하지 못하는 문제
> 에러 로그: `Query did not return a unique result: 2 results were returned`

문제 상황) 이전 지원서를 조회할 때 지원자 id로만 조회하고 있었음.

해결) 모집공고 id도 쿼리 조건에 포함시킴.

**에러 로그를 저장할 때 stack trace의 일부를 저장하고 있었는데, stack trace 전체를 포함시키는게 버그 확인할 때 좋을 듯함** ㅜ

### 모집공고 조회 N+1 문제
>쿼리를 검토해봤더니 question들에 대해 N+1 문제가 발생하고 있었음. 

문제 상황) Section에서 조회한 NarrativeQuestion을 페치해주는 부분인데, `clear`하면서 섹션의 모든 NarrativeQuestion을 조회함
```java
// Section.java
        narrativeQuestions.forEach(narrativeQuestion -> narrativeQuestion.updateSection(this));
        this.narrativeQuestions.clear();
        this.narrativeQuestions.addAll(narrativeQuestions);
```
Recruitment(Section 페치 조인해서 함께), NarrativeQuestion, SelectiveQuestion 을 조회해서 페치해주고 있었음

해결) Section과 함께 NarrativeQuestion, SelectiveQuestion을 페치 조인해서 가져오고 Recruitment에 페치하기
```java
// RecruitmentDetailsLoader.java
    private Recruitment fetchQuestions(Recruitment recruitment) {
        Long recruitmentId = recruitment.getId();
        List<Section> sections = sectionRepository.findAllWithQuestionsByRecruitmentId(recruitmentId);
        recruitment.replaceSectionsWithFetchedData(sections);
        return recruitment;
    }

// Recruitment.java
    public void replaceSectionsWithFetchedData(List<Section> sections) {
        this.sections.clear();
        this.sections.addAll(sections);
    }
```
이때 `this.sections.clear()` 가 있기 때문에 Recruitment 조회 시 Section 페치 조인하는 걸 유지함.


