### PR TITLE
이미 발표된 모집 공고를 모집 공고 마감에서 제외

### DIFF
--- a/src/main/java/com/server/crews/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/server/crews/recruitment/domain/Recruitment.java
@@ -37,7 +37,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
         indexes = {
                 @Index(columnList = "publisher_id", name = "idx_publisher_id"),
                 @Index(columnList = "code", name = "idx_code"),
-                @Index(columnList = "title", name = "idx_title")
+                @Index(columnList = "title", name = "idx_title"),
+                @Index(columnList = "deadline, progress", name = "idx_deadline_progress")
         }
 )
 @EntityListeners(AuditingEntityListener.class)

--- a/src/main/java/com/server/crews/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/server/crews/recruitment/repository/RecruitmentRepository.java
@@ -1,6 +1,9 @@
 package com.server.crews.recruitment.repository;
 
 import com.server.crews.recruitment.domain.Recruitment;
+import com.server.crews.recruitment.domain.RecruitmentProgress;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -41,4 +44,6 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> 
             where r.title = :title
             """)
     Optional<Recruitment> findWithSectionsByTitle(@Param("title") String title);
+
+    List<Recruitment> findByDeadlineLessThanEqualAndProgressNot(LocalDateTime deadline, RecruitmentProgress progress);
 }

--- a/src/main/java/com/server/crews/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/server/crews/recruitment/service/RecruitmentService.java
@@ -146,12 +146,8 @@ public class RecruitmentService {
     @Scheduled(cron = "${schedules.cron.closing-recruitment}")
     public void closeRecruitments() {
         LocalDateTime now = LocalDateTime.now(clock);
-        List<Recruitment> recruitments = recruitmentRepository.findAll();
-
-        List<Recruitment> recruitmentsToBeClosed = recruitments.stream()
-                .filter(recruitment -> recruitment.hasOnOrAfterDeadline(now))
-                .filter(recruitment -> !recruitment.isAnnounced())
-                .toList();
+        List<Recruitment> recruitmentsToBeClosed = recruitmentRepository.findByDeadlineLessThanEqualAndProgressNot(now,
+                RecruitmentProgress.ANNOUNCED);
         recruitmentsToBeClosed.forEach(Recruitment::close);
 
         String closedRecruitmentIds = recruitmentsToBeClosed.stream()

--- a/src/main/java/com/server/crews/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/server/crews/recruitment/service/RecruitmentService.java
@@ -147,10 +147,13 @@ public class RecruitmentService {
     public void closeRecruitments() {
         LocalDateTime now = LocalDateTime.now(clock);
         List<Recruitment> recruitments = recruitmentRepository.findAll();
+
         List<Recruitment> recruitmentsToBeClosed = recruitments.stream()
                 .filter(recruitment -> recruitment.hasOnOrAfterDeadline(now))
+                .filter(recruitment -> !recruitment.isAnnounced())
                 .toList();
         recruitmentsToBeClosed.forEach(Recruitment::close);
+
         String closedRecruitmentIds = recruitmentsToBeClosed.stream()
                 .map(Recruitment::getId)
                 .map(String::valueOf)

--- a/src/test/java/com/server/crews/recruitment/repository/RecruitmentRepositoryTest.java
+++ b/src/test/java/com/server/crews/recruitment/repository/RecruitmentRepositoryTest.java
@@ -11,8 +11,9 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import com.server.crews.auth.domain.Administrator;
 import com.server.crews.environ.repository.RepositoryTest;
 import com.server.crews.recruitment.domain.Recruitment;
-import com.server.crews.recruitment.repository.RecruitmentRepository;
+import com.server.crews.recruitment.domain.RecruitmentProgress;
 import jakarta.validation.ConstraintViolationException;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -50,5 +51,20 @@ class RecruitmentRepositoryTest extends RepositoryTest {
         // when & then
         assertThatThrownBy(() -> recruitmentRepository.save(recruitment))
                 .isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    @DisplayName("기준보다 이전 마감일과 모집 단계로 모집 공고 목록을 조회한다.")
+    void findByDeadlineLessThanEqualAndProgressNot() {
+        // given
+        Administrator publisher = createDefaultAdmin();
+        createDefaultRecruitment(publisher);
+
+        // when
+        List<Recruitment> recruitments = recruitmentRepository.findByDeadlineLessThanEqualAndProgressNot(
+                LocalDateTime.of(2030, 10, 5, 18, 0), RecruitmentProgress.ANNOUNCED);
+
+        // then
+        assertThat(recruitments).hasSize(1);
     }
 }


### PR DESCRIPTION
## Description 📒

>- 모집공고 마감은 마감일이 지나고, 결과메일이 전송되지 않은 모집공고를 대상으로 한다. 
>- 버그 고치는 김에 쿼리도 수정해서 필터링을 애플리케이션이 아니라 DB에서 하도록 변경. (복잡한 쿼리가 아니니 메모리 절약겸)

